### PR TITLE
Change BluePay constructor to use __construct

### DIFF
--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -101,7 +101,7 @@ class BluePay {
     // $accID : Merchant's Account ID
     // $secretKey : Merchant's Secret Key
     // $mode : Transaction mode of either LIVE or TEST (default)
-    public function BluePay($accID, $secretKey, $mode) {
+    public function __construct($accID, $secretKey, $mode) {
         $this->accountID = $accID;
         $this->secretKey = $secretKey;
         $this->mode = $mode;


### PR DESCRIPTION
Fixes issue #4 use __construct so this works with php 7+ versions