### PR TITLE
Handles both 0s and *s as placeholders

### DIFF
--- a/C#/BluePay.cs
+++ b/C#/BluePay.cs
@@ -37,8 +37,8 @@ namespace BluePayLibrary
         public string paymentAccount = "";
         public string cvv2 = "";
         public string cardExpire = "";
-        public Regex track1And2 = new Regex(@"(%B)\d{0,19}\^([\w\s]*)\/([\w\s]*)([\s]*)\^\d{7}\w*\?;\d{0,19}=\d{7}\w*\?");
-        public Regex track2Only = new Regex(@";\d{0,19}=\d{7}\w*\?");
+        public Regex track1And2 = new Regex(@"(%B)[\d\*]{0,19}\^([\w\s]*)\/([\w\s]*)([\s]*)\^[\d\*]{7}[\w*]*\?;[\d\*]{0,19}=[\d\*]{7}[\w*]*\?");
+        public Regex track2Only = new Regex(@";[\d\*]{0,19}=[\d\*]{7}[\w*]*\?");
         public string swipeData = "";
         public string routingNum = "";
         public string accountNum = "";


### PR DESCRIPTION
MagTek sent us Blue Pay encrypted swipes that use asterisks instead of zeros as place holders. This update to the regex expression handles both.