### PR TITLE
Hmac

### DIFF
--- a/Perl/bluepay.pm
+++ b/Perl/bluepay.pm
@@ -63,7 +63,6 @@ sub generate_tps {
 # calculates tamper proof seal based on api declared
 sub calc_tps {
     my $self = shift;
-    $self->{TPS_HASH_TYPE} = 'HMAC_SHA512';
     my $TAMPER_PROOF_DATA = '';
 
     if ($self->{API} eq 'bpdailyreport2' ) {

--- a/Perl/bluepay.pm
+++ b/Perl/bluepay.pm
@@ -39,7 +39,7 @@ sub generate_tps {
 
     if ($self->{TPS_HASH_TYPE} eq 'HMAC_SHA256')
     {
-        $hash = hmac_sha512_hex($str, $self->{SECRET_KEY});
+        $hash = hmac_sha256_hex($str, $self->{SECRET_KEY});
     }
     elsif ($self->{TPS_HASH_TYPE} eq 'SHA512')
     {


### PR DESCRIPTION
Fix some issues with Perl generateTPS function. TPS_HASH_TYPE was being redefined and the wrong hash function was being called.