### PR TITLE
Update with HMAC functionality

### DIFF
--- a/C#/BluePay.cs
+++ b/C#/BluePay.cs
@@ -126,7 +126,7 @@ namespace BluePayLibrary
         public string BPheaderstring = "";
 
         public int numRetries = 0;
-        public string tpsHashType = "MD5";
+        public string tpsHashType = "HMAC_SHA512";
 
         // level 2 processing field
         public Dictionary<string, string> level2Info = new Dictionary<string, string>();

--- a/C#/BluePay.cs
+++ b/C#/BluePay.cs
@@ -1074,7 +1074,7 @@ namespace BluePayLibrary
                     "&AMOUNT_MISC=" + HttpUtility.UrlEncode(this.amountMisc) +
                     "&REMOTE_IP=" + System.Net.Dns.GetHostEntry("").AddressList[0].ToString() +
                     "&TPS_HASH_TYPE=" + HttpUtility.UrlEncode(this.tpsHashType) +
-                    "&RESPONSEVERSION=1";
+                    "&RESPONSEVERSION=5";
                     if (this.swipeData != "")
                     {
                         Match matchTrack1And2 = track1And2.Match(this.swipeData);

--- a/C#/BluePay.cs
+++ b/C#/BluePay.cs
@@ -99,6 +99,8 @@ namespace BluePayLibrary
         public string shpfFormID = "";
         public string receiptFormID = "";
         public string remoteURL = "";
+        public string shpfTpsHashType = "";
+        public string receiptTpsHashType = "";
         public string cardTypes = "";
         public string receiptTpsDef = "";
         public string receiptTpsString = "";
@@ -653,7 +655,7 @@ namespace BluePayLibrary
                                     + this.rebillAmount
                                     + this.masterID
                                     + this.mode;
-            this.TPS = GenerateTPS(tamper_proof_seal);
+            this.TPS = GenerateTPS(tamper_proof_seal, this.tpsHashType);
         }
 
         /// <summary>
@@ -662,7 +664,7 @@ namespace BluePayLibrary
         public void CalcRebillTPS()
         {
             string tamper_proof_seal = this.accountID + this.transType + this.rebillID;
-            this.TPS = GenerateTPS(tamper_proof_seal);
+            this.TPS = GenerateTPS(tamper_proof_seal, this.tpsHashType);
         }
 
         /// <summary>
@@ -671,44 +673,18 @@ namespace BluePayLibrary
         public void CalcReportTPS()
         {
             string tamper_proof_seal = this.accountID + this.reportStartDate + this.reportEndDate;
-            this.TPS = GenerateTPS(tamper_proof_seal);
-        }
-
-        /// <summary>
-        /// Calculates BP_STAMP for trans notify post API
-        /// </summary>
-        /// <param name="secretKey"></param>
-        /// <param name="transID"></param>
-        /// <param name="transStatus"></param>
-        /// <param name="transType"></param>
-        /// <param name="amount"></param>
-        /// <param name="batchID"></param>
-        /// <param name="batchStatus"></param>
-        /// <param name="totalCount"></param>
-        /// <param name="totalAmount"></param>
-        /// <param name="batchUploadID"></param>
-        /// <param name="rebillID"></param>
-        /// <param name="rebillAmount"></param>
-        /// <param name="rebillStatus"></param>
-        /// <returns></returns>
-        public static string CalcTransNotifyTPS(string transID, string transStatus, string transType,
-            string amount, string batchID, string batchStatus, string totalCount, string totalAmount,
-            string batchUploadID, string rebillID, string rebillAmount, string rebillStatus)
-        {
-            string tamper_proof_seal = transID + transStatus + transType + amount + batchID + batchStatus +
-            totalCount + totalAmount + batchUploadID + rebillID + rebillAmount + rebillStatus;
-            return GenerateTPS(tamper_proof_seal);
+            this.TPS = GenerateTPS(tamper_proof_seal, this.tpsHashType);
         }
 
         /// <summary>
         /// Generates the TAMPER_PROOF_SEAL to used to validate each transaction
         /// </summary>
-        public string GenerateTPS(string Message)
+        public string GenerateTPS(string Message, string HashType)
         {
             string tpsHash = "";
             ASCIIEncoding encode = new ASCIIEncoding();
 
-            if (this.tpsHashType == "HMAC_SHA256")
+            if (HashType == "HMAC_SHA256")
             {
                 byte[] SecretKeyBytes = encode.GetBytes(this.secretKey);
                 byte[] MessageBytes = encode.GetBytes(Message);
@@ -716,21 +692,21 @@ namespace BluePayLibrary
                 byte[] HashBytes = Hmac.ComputeHash(MessageBytes);
                 tpsHash = ByteArrayToString(HashBytes);
             }
-            else if (this.tpsHashType == "SHA512")
+            else if (HashType == "SHA512")
             {
                 SHA512 sha512 = new SHA512CryptoServiceProvider();
                 byte[] buffer = encode.GetBytes(this.secretKey + Message);
                 byte[] Hash = sha512.ComputeHash(buffer);
                 tpsHash = ByteArrayToString(Hash);
             }
-            else if (this.tpsHashType == "SHA256")
+            else if (HashType == "SHA256")
             {
                 SHA256 Sha256 = new SHA256CryptoServiceProvider();
                 byte[] Buffer = encode.GetBytes(this.secretKey + Message);
                 byte[] Hash = Sha256.ComputeHash(Buffer);
                 tpsHash = ByteArrayToString(Hash);
             }
-            else if (this.tpsHashType == "MD5")
+            else if (HashType == "MD5")
             {
                 MD5 Md5 = new MD5CryptoServiceProvider();
                 byte[] Buffer = encode.GetBytes(this.secretKey + Message);
@@ -845,18 +821,39 @@ namespace BluePayLibrary
             this.shpfFormID = paymentTemplate;
             this.receiptFormID = receiptTemplate;
             this.remoteURL = receiptTempRemoteURL;
+            this.shpfTpsHashType = "HMAC_SHA512";
+            this.receiptTpsHashType = this.shpfTpsHashType;
+            this.tpsHashType = SetHashType(tpsHashType);
             this.cardTypes = SetCardTypes();
-            this.receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF";
+            this.receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE";
             this.receiptTpsString = SetReceiptTpsString();
-            this.receiptTamperProofSeal = CalcURLTps(receiptTpsString);
+            this.receiptTamperProofSeal = GenerateTPS(receiptTpsString, this.receiptTpsHashType);
             this.receiptURL = SetReceiptURL();
-            this.bp10emuTpsDef = AddDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF");
+            this.bp10emuTpsDef = AddDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF TPS_HASH_TYPE");
             this.bp10emuTpsString = SetBp10emuTpsString();
-            this.bp10emuTamperProofSeal = CalcURLTps(bp10emuTpsString);
-            this.shpfTpsDef = AddDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF SHPF_TPS_DEF");
+            this.bp10emuTamperProofSeal = GenerateTPS(bp10emuTpsString, this.tpsHashType);
+            this.shpfTpsDef = AddDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF TPS_HASH_TYPE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE");
             this.shpfTpsString = SetShpfTpsString();
-            this.shpfTamperProofSeal = CalcURLTps(shpfTpsString);
+            this.shpfTamperProofSeal = GenerateTPS(shpfTpsString, this.shpfTpsHashType);
             return CalcURLResponse();
+        }
+
+        /// <summary>
+        /// Validates chosen hash type or returns default hash.
+        /// </summary>
+        public string SetHashType(string chosen_hash)
+        {
+            string default_hash = "HMAC_SHA512";
+            chosen_hash = chosen_hash.ToUpper();
+            string result = "";
+            string[] hashes = { "MD5", "SHA256", "SHA512", "HMAC_SHA256" };
+            int pos = Array.IndexOf(hashes, chosen_hash);
+            if (pos > -1){
+                result = chosen_hash;
+            } else {
+                result = default_hash;
+            }
+            return result;
         }
 
         /// <summary>
@@ -875,7 +872,7 @@ namespace BluePayLibrary
         /// </summary>
         public string SetReceiptTpsString()
         {
-            return secretKey + accountID + receiptFormID + returnURL + dba + amexImage + discoverImage + receiptTpsDef;
+            return accountID + receiptFormID + returnURL + dba + amexImage + discoverImage + receiptTpsDef + receiptTpsHashType;
         }
 
         /// <summary>
@@ -883,7 +880,7 @@ namespace BluePayLibrary
         /// </summary>
         public string SetBp10emuTpsString()
         {
-            string bp10emu = secretKey + accountID + receiptURL + receiptURL + receiptURL + mode + transType + bp10emuTpsDef;
+            string bp10emu = accountID + receiptURL + receiptURL + receiptURL + mode + transType + bp10emuTpsDef + tpsHashType;
             return AddStringProtectedStatus(bp10emu);
         }
 
@@ -892,7 +889,7 @@ namespace BluePayLibrary
         /// </summary>
         public string SetShpfTpsString()
         {
-            string shpf = secretKey + shpfFormID + accountID + dba + bp10emuTamperProofSeal + amexImage + discoverImage + bp10emuTpsDef + shpfTpsDef;
+            string shpf = shpfFormID + accountID + dba + bp10emuTamperProofSeal + amexImage + discoverImage + bp10emuTpsDef + tpsHashType + shpfTpsDef + shpfTpsHashType;
             return AddStringProtectedStatus(shpf);
         }
 
@@ -909,6 +906,7 @@ namespace BluePayLibrary
                 output = "https://secure.bluepay.com/interfaces/shpf?SHPF_FORM_ID=" + receiptFormID +
                 "&SHPF_ACCOUNT_ID=" + accountID +
                 "&SHPF_TPS_DEF=" + EncodeURL(receiptTpsDef) +
+                "&SHPF_TPS_HASH_TYPE=" + EncodeURL(receiptTpsHashType) +
                 "&SHPF_TPS=" + EncodeURL(receiptTamperProofSeal) +
                 "&RETURN_URL=" + EncodeURL(returnURL) +
                 "&DBA=" + EncodeURL(dba) +
@@ -972,21 +970,6 @@ namespace BluePayLibrary
         }
 
         /// <summary>
-        /// Generates a Tamperproof Seal for a url. Must be used with GenerateURL.
-        /// </summary>
-        public string CalcURLTps(string input)
-        {
-            MD5 md5Hash = MD5.Create();
-            byte[] data = md5Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
-            StringBuilder sBuilder = new StringBuilder();
-            for (int i = 0; i < data.Length; i++)
-            {
-                sBuilder.Append(data[i].ToString("x2"));
-            }
-            return sBuilder.ToString();
-        }
-
-        /// <summary>
         /// Generates the final url for the Simple Hosted Payment Form. Must be used with GenerateURL.
         /// </summary>
         public string CalcURLResponse()
@@ -996,6 +979,7 @@ namespace BluePayLibrary
             "SHPF_FORM_ID=" + EncodeURL(shpfFormID) +
             "&SHPF_ACCOUNT_ID=" + EncodeURL(accountID) +
             "&SHPF_TPS_DEF=" + EncodeURL(shpfTpsDef) +
+            "&SHPF_TPS_HASH_TYPE=" + EncodeURL(shpfTpsHashType) +
             "&SHPF_TPS=" + EncodeURL(shpfTamperProofSeal) +
             "&MODE=" + EncodeURL(mode) +
             "&TRANSACTION_TYPE=" + EncodeURL(transType) +
@@ -1013,6 +997,7 @@ namespace BluePayLibrary
             "&DISCOVER_IMAGE=" + EncodeURL(discoverImage) +
             "&REDIRECT_URL=" + EncodeURL(receiptURL) +
             "&TPS_DEF=" + EncodeURL(bp10emuTpsDef) +
+            "&TPS_HASH_TYPE=" + EncodeURL(tpsHashType) +
             "&CARD_TYPES=" + EncodeURL(cardTypes);
         }
 
@@ -1089,7 +1074,7 @@ namespace BluePayLibrary
                     "&AMOUNT_MISC=" + HttpUtility.UrlEncode(this.amountMisc) +
                     "&REMOTE_IP=" + System.Net.Dns.GetHostEntry("").AddressList[0].ToString() +
                     "&TPS_HASH_TYPE=" + HttpUtility.UrlEncode(this.tpsHashType) +
-                    "&RESPONSEVERSION=3";
+                    "&RESPONSEVERSION=1";
                     if (this.swipeData != "")
                     {
                         Match matchTrack1And2 = track1And2.Match(this.swipeData);
@@ -1230,7 +1215,7 @@ namespace BluePayLibrary
             HttpWebResponse httpResponse = (HttpWebResponse)request.Response;
 
         }
-
+        
         public bool IsSuccessfulTransaction()
         {
             string status = this.GetStatus();

--- a/C#/Get_Data/Transaction_Notification.cs
+++ b/C#/Get_Data/Transaction_Notification.cs
@@ -21,9 +21,18 @@ namespace GetData
     {
         public static void Main()
         {
+            string accountID = "Merchant's Account ID Here";
+            string secretKey = "Merchant's Secret Key Here";
+            string mode = "TEST";
+            
+            BluePay tps = new BluePay
+            (
+                accountID,
+                secretKey,
+                mode
+            );
 
             HttpListener listener = new HttpListener();
-            string secretKey = "";
             string response = "";
 
             try
@@ -65,42 +74,35 @@ namespace GetData
             string transStatus = vals["trans_stats"];
             string transType = vals["trans_type"];
             string amount = vals["amount"];
-            string batchID = vals["batch_id"];
-            string batchStatus = vals["batch_status"];
-            string totalCount = vals["total_count"];
-            string totalAmount = vals["total_amount"];
-            string batchUploadID = vals["batch_upload_id"];
             string rebillID = vals["rebill_id"];
             string rebillAmount = vals["rebill_amount"];
             string rebillStatus = vals["rebill_status"];
+            string tpsHashType = vals["TPS_HASH_TYPE"];
+            string bpStamp = vals["BP_STAMP"];
+            string bpStampDef = vals["BP_STAMP_DEF"];
 
             // calculate the expected BP_STAMP
-            string bpStamp = BluePay.CalcTransNotifyTPS(secretKey,
-                vals["trans_id"],
-                vals["trans_stats"],
-                vals["trans_type"],
-                vals["amount"],
-                vals["batch_id"],
-                vals["batch_status"],
-                vals["total_count"],
-                vals["total_amount"],
-                vals["batch_upload_id"],
-                vals["rebill_id"],
-                vals["rebill_amount"],
-                vals["rebill_status"]);
+            string bpStampString = "";
+            string[] defSeparator = new string[] { " " };
+            string[] bpStampFields = bpStampDef.Split(defSeparator, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string field in bpStampFields)
+            {
+                bpStampString += vals[field];
+            }
+            string expectedStamp = tps.GenerateTPS(bpStampString, tpsHashType);
 
             // Output data if the expected BP_STAMP matches the actual BP_STAMP
-            if (bpStamp == vals["BP_STAMP"]) {
+            if (expectedStamp == bpStamp) {
                 Console.Write("Transaction ID: " + transID);
-            Console.Write("Transaction Status: " + transStatus);
-            Console.Write("Transaction Type: " + transType);
-            Console.Write("Transaction Amount: " + amount);
-            Console.Write("Rebill ID: " + rebillID);
-            Console.Write("Rebill Amount: " + rebillAmount);
-            Console.Write("Rebill Status: " + rebillStatus);
-    } else {
+                Console.Write("Transaction Status: " + transStatus);
+                Console.Write("Transaction Type: " + transType);
+                Console.Write("Transaction Amount: " + amount);
+                Console.Write("Rebill ID: " + rebillID);
+                Console.Write("Rebill Amount: " + rebillAmount);
+                Console.Write("Rebill Status: " + rebillStatus);
+            } else {
                 Console.Write("ERROR IN RECEIVING DATA FROM BLUEPAY");
-    }
+            }
         }
     }
 }

--- a/C#/Get_Data/Validate_BP_Stamp.cs
+++ b/C#/Get_Data/Validate_BP_Stamp.cs
@@ -1,0 +1,93 @@
+/*
+* BluePay C#.NET Sample code.
+*
+* This code sample reads the values from a BP10emu redirect
+* and authenticates the message using the the BP_STAMP
+* provided in the response. Point the REDIRECT_URL of your 
+* BP10emu request to the URI prefix specified below.
+*/
+
+using System;
+using BluePayLibrary;
+using System.Collections.Specialized;
+using System.Web;
+using System.Net;
+using System.IO;
+using System.Text;
+
+namespace GetData
+{
+    class ValidateBPStamp
+    {
+        public static void Main()
+        {
+            string accountID = "Merchant's Account ID Here";
+            string secretKey = "Merchant's Secret Key Here";
+            string mode = "TEST";
+            string prefix = "Merchant's Target URI Prefix Here" // Set the listener URI (and port if necessary)
+
+            HttpListener listener = new HttpListener();
+            listener.Prefixes.Add(prefix); 
+
+            try
+            {
+                // Listen for incoming data
+                listener.Start();
+            }
+            catch (HttpListenerException)
+            {
+                return;
+            }
+            while (listener.IsListening)
+            {
+                var context = listener.GetContext();
+                NameValueCollection responsePairs = context.Request.QueryString;
+                string msg;
+                if (responsePairs["BP_STAMP"] != null) // Check whether BP_STAMP is provided
+                {
+                    BluePay bp = new BluePay
+                    (
+                       accountID,
+                       secretKey,
+                       mode
+                    );
+                    
+                    string bpStampString = "";
+                    string[] defSeparator = new string[] { " " };
+                    string[] bpStampFields = responsePairs["BP_STAMP_DEF"].Split(defSeparator, StringSplitOptions.RemoveEmptyEntries); // Split BP_STAMP_DEF on whitespace
+                    foreach (string field in bpStampFields)
+                    {
+                        bpStampString += responsePairs[field]; // Concatenate values used to calculate expected BP_STAMP
+                    }
+                    string expectedStamp = bp.GenerateTPS(bpStampString, responsePairs["TPS_HASH_TYPE"]); // Calculate expected BP_STAMP using hash function specified in response
+                    if (expectedStamp == responsePairs["BP_STAMP"]) // Compare expected BP_STAMP with received BP_STAMP
+                    {
+                        // Validate BP_STAMP and reads the response results
+                        msg = "VALID BP_STAMP: TRUE\n";
+                        foreach (string key in responsePairs)
+                        {
+                            msg += (key + ": " + responsePairs[key] + "\n");
+                        }
+                    }
+                    else
+                    {
+                        msg = "ERROR: BP_STAMP VALUES DO NOT MATCH\n";
+                    }
+                } else
+                {
+                    msg = "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION";
+                }
+                context.Response.ContentLength64 = Encoding.UTF8.GetByteCount(msg);
+                context.Response.StatusCode = 200;
+                using (Stream stream = context.Response.OutputStream)
+                {
+                    using (StreamWriter writer = new StreamWriter(stream))
+                    {
+                        writer.Write(msg);
+                    }
+                }
+            }
+            listener.Close();
+        }
+    }
+}

--- a/C#/Program.cs
+++ b/C#/Program.cs
@@ -15,6 +15,7 @@ namespace bluepayc
 			// RetrieveSettlementData.Main();
 			// RetrieveTransactionData.Main();
 			// SingleTransactionQuery.Main();
+            // ValidateBPStamp.Main();
 
 			// REBILL
 			// CancelRecurringPayment.Main();

--- a/C#/Program.cs
+++ b/C#/Program.cs
@@ -15,6 +15,7 @@ namespace bluepayc
 			// RetrieveSettlementData.Main();
 			// RetrieveTransactionData.Main();
 			// SingleTransactionQuery.Main();
+			// TransactionNotification.Main();
             // ValidateBPStamp.Main();
 
 			// REBILL

--- a/C++/Get_Data/Validate_BP_Stamp.cpp
+++ b/C++/Get_Data/Validate_BP_Stamp.cpp
@@ -1,0 +1,150 @@
+//
+// BluePay C++ Sample code.
+//
+// This code sample reads the values from a BP10emu redirect
+// and authenticates the message using the the BP_STAMP
+// provided in the response. Point the REDIRECT_URL of your
+// BP10emu request to the URI prefix specified below.
+//
+
+#include "Validate_BP_Stamp.h"
+#include "../bluepay-cpp/BluePay.h"
+#include <regex>
+#include <map>
+#include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sstream>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+void error(const char *msg)
+{
+    perror(msg);
+    exit(1);
+}
+
+void validateBPStamp(){
+    // Set account credentials
+    std::string accountId = "Merchant's Account ID Here";
+    std::string secretKey = "Merchant's Secret Key Here";
+    std::string mode = "TEST";
+    
+    int server_socket, client_socket;
+    ssize_t n;
+    int portno = 9000; // Merchant's port number here
+    char buffer[2048];
+    bzero(buffer,2048);
+    
+    // Create new socket
+    server_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_socket < 0)
+        error("ERROR opening socket");
+    struct sockaddr_in server_address, client_address;
+    bzero((char *) &server_address, sizeof(server_address));
+    
+    // Define server address
+    server_address.sin_family = AF_INET;
+    server_address.sin_addr.s_addr = INADDR_ANY;
+    server_address.sin_port = htons(portno);
+    
+    // Bind socket to server address
+    if (bind(server_socket, (struct sockaddr *) &server_address,
+             sizeof(server_address)) < 0)
+        error("ERROR on binding");
+    
+    // Listen for incoming connections; max 5
+    listen(server_socket,5);
+    
+    // Accept incoming connection
+    while(1) {
+        socklen_t client_length;
+        client_length = sizeof(client_address);
+        client_socket = accept(server_socket,
+                               (struct sockaddr *) &client_address,
+                               &client_length);
+        if (client_socket < 0)
+            error("ERROR on accept");
+        
+        // Receive request
+        n = read(client_socket,buffer,2048);
+        if (n < 0) error("ERROR reading from socket");
+        
+        // Parse query string
+        std::istringstream iss(buffer);
+        std::string method, query, protocol;
+        if(!(iss >> method >> query >> protocol))
+            error("ERROR on parsing request");
+        iss.clear();
+        iss.str(query);
+        
+        std::string url;
+        if(!std::getline(iss, url, '?'))
+            error("ERROR on parsing request");
+        
+        std::map<std::string, std::string> responsePairs;
+        std::string keyval, key, val;
+        
+        while(std::getline(iss, keyval, '&'))
+        {
+            std::istringstream iss(keyval);
+            if(std::getline(std::getline(iss, key, '='), val))
+                responsePairs[key] = val;
+        }
+        
+        // Build response body
+        std::stringstream ss_body;
+        
+        // Validate BP_STAMP
+        if (responsePairs.find("BP_STAMP") == responsePairs.end()) { // Check whether BP_STAMP is provided
+            ss_body << "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION";
+        } else {
+            BluePay bp(
+                       accountId,
+                       secretKey,
+                       mode
+                       );
+            
+            std::string bpStamp = responsePairs["BP_STAMP"];
+            std::string bpStampDef = bp.urlDecode(responsePairs["BP_STAMP_DEF"]);
+            std::string bpStampString = "";
+            std::vector<std::string> bpStampFields = bp.split(bpStampDef, ' '); // Split BP_STAMP_DEF on whitespace
+            for (std::string field : bpStampFields) {
+                bpStampString += responsePairs[field]; // Concatenate values used to calculate expected BP_STAMP
+            }
+            bpStampString = bp.urlDecode(bpStampString);
+            std::string calculatedStamp = bp.generateTps(bpStampString, responsePairs["TPS_HASH_TYPE"]); // Calculate expected BP_STAMP using hash function specified in response
+            std::transform(calculatedStamp.begin(), calculatedStamp.end(),calculatedStamp.begin(), ::toupper);
+            
+            if(calculatedStamp == bpStamp){ // Compare expected BP_STAMP with received BP_STAMP
+                // Validate BP_STAMP and reads the response results
+                ss_body << "VALID BP_STAMP: TRUE<br/>";
+                for(auto const& pair: responsePairs){
+                    ss_body << pair.first << ": " << pair.second << "<br/>";
+                }
+            } else
+            {
+                ss_body << "ERROR: BP_STAMP VALUES DO NOT MATCH\n";
+            }
+        }
+        std::string body = ss_body.str();
+        
+        // Build response headers
+        std::stringstream ss_header;
+        ss_header <<"HTTP/1.1 200 OK\r\n"
+        << "Content-Type: text/html\n"
+        << "Content-Length: " << body.length() << '\n'
+        << "Connection: close\n"
+        << '\n' << body;
+        const char* http_headers = ss_header.str().c_str();
+        
+        // Write response
+        n = write(client_socket,http_headers,strlen(http_headers));
+        if (n < 0) error("ERROR writing to socket");
+        close(client_socket);
+        bzero(buffer,2048);
+    }
+}

--- a/C++/Get_Data/Validate_BP_Stamp.h
+++ b/C++/Get_Data/Validate_BP_Stamp.h
@@ -1,0 +1,12 @@
+//
+//  Validate_BP_Stamp.h
+//  bluepay-cpp
+//
+
+
+#ifndef __bluepay_cpp__Validate_BP_Stamp__
+#define __bluepay_cpp__Validate_BP_Stamp__
+#include <stdio.h>
+void validateBPStamp();
+
+#endif /* defined(__bluepay_cpp__Validate_BP_Stamp__) */

--- a/C++/bluepay-cpp/BluePay.cpp
+++ b/C++/bluepay-cpp/BluePay.cpp
@@ -1202,7 +1202,7 @@ char* BluePay::process()
         "&STATUS=" + (this->rebillStatus);
     }
     // Add Response version to return
-    postData += "&RESPONSEVERSION=1";
+    postData += "&RESPONSEVERSION=5";
     
     // Add Level 2 data, if available.
     for( auto field : level2Info )

--- a/C++/bluepay-cpp/BluePay.cpp
+++ b/C++/bluepay-cpp/BluePay.cpp
@@ -806,32 +806,6 @@ void BluePay::calcReportTps()
 }
 
 /// <summary>
-/// Calculates BP_STAMP for trans notify post API
-/// </summary>
-/// <param name="secretKey"></param>
-/// <param name="transId"></param>
-/// <param name="transStatus"></param>
-/// <param name="transType"></param>
-/// <param name="amount"></param>
-/// <param name="batchId"></param>
-/// <param name="batchStatus"></param>
-/// <param name="totalCount"></param>
-/// <param name="totalAmount"></param>
-/// <param name="batchUploadId"></param>
-/// <param name="rebillId"></param>
-/// <param name="rebillAmount"></param>
-/// <param name="rebillStatus"></param>
-/// <returns></returns>
-std::string BluePay::calcTransNotifyTps(std::string secretKey, std::string transId, std::string transStatus, std::string transType,
-    std::string amount, std::string batchId, std::string batchStatus, std::string totalCount, std::string totalAmount,
-    std::string batchUploadId, std::string rebillId, std::string rebillAmount, std::string rebillStatus)
-{
-  std::string tamper_proof_seal = secretKey + transId + transStatus + transType + amount + batchId + batchStatus +
-    totalCount + totalAmount + batchUploadId + rebillId + rebillAmount + rebillStatus;
-  return md5(tamper_proof_seal);
-}
-
-/// <summary>
 /// Sets the types of credit card images to use on the Simple Hosted Payment Form. Must be used with GenerateURL.
 /// </summary>
 std::string BluePay::setCardTypes() 

--- a/C++/bluepay-cpp/BluePay.cpp
+++ b/C++/bluepay-cpp/BluePay.cpp
@@ -758,17 +758,17 @@ void BluePay::setEmail(std::string Email)
 /// <summary>
 /// Generates the TAMPER_PROOF_SEAL to used to validate each transaction
 /// </summary>
-std::string BluePay::generateTps(std::string message)
+std::string BluePay::generateTps(std::string message, std::string hashType)
 {
     std::string result = "";
-    if (this->tpsHashType == "HMAC_SHA256") {
+    if (hashType == "HMAC_SHA256") {
         Hmac h(this->secretKey, message, "SHA256");
         result = h.calcHmac();
-    } else if (this->tpsHashType == "SHA512") {
+    } else if (hashType == "SHA512") {
         result = sha512(this->secretKey + message);
-    } else if (this->tpsHashType == "SHA256") {
+    } else if (hashType == "SHA256") {
        result = sha256(this->secretKey + message);
-    } else if (this->tpsHashType == "MD5") {
+    } else if (hashType == "MD5") {
         result = md5(this->secretKey + message);
     } else {
         Hmac h(this->secretKey, message, "SHA512");
@@ -784,7 +784,7 @@ void BluePay::calcTps()
 {
   std::string tamper_proof_seal = this->accountId + this->transType + this->amount + this->doRebill + this->rebillFirstDate +
     this->rebillExpr + this->rebillCycles + this->rebillAmount + this->masterId + this->mode;
-  this->Tps = generateTps(tamper_proof_seal);
+  this->Tps = generateTps(tamper_proof_seal, this->tpsHashType);
 }
 
 /// <summary>
@@ -793,7 +793,7 @@ void BluePay::calcTps()
 void BluePay::calcRebillTps()
 {
   std::string tamper_proof_seal = this->accountId + this->transType + this->rebillId;
-  this->Tps = generateTps(tamper_proof_seal);
+  this->Tps = generateTps(tamper_proof_seal, this->tpsHashType);
 }
 
 /// <summary>
@@ -802,7 +802,7 @@ void BluePay::calcRebillTps()
 void BluePay::calcReportTps()
 {
   std::string tamper_proof_seal = this->accountId + this->reportStartDate + this->reportEndDate;
-  this->Tps = generateTps(tamper_proof_seal);
+  this->Tps = generateTps(tamper_proof_seal, this->tpsHashType);
 }
 
 /// <summary>
@@ -822,14 +822,13 @@ void BluePay::calcReportTps()
 /// <param name="rebillAmount"></param>
 /// <param name="rebillStatus"></param>
 /// <returns></returns>
-std::string BluePay::calcTransNotifyTps(std::string transId, std::string transStatus, std::string transType,
+std::string BluePay::calcTransNotifyTps(std::string secretKey, std::string transId, std::string transStatus, std::string transType,
     std::string amount, std::string batchId, std::string batchStatus, std::string totalCount, std::string totalAmount,
     std::string batchUploadId, std::string rebillId, std::string rebillAmount, std::string rebillStatus)
 {
-  std::string tamper_proof_seal = transId + transStatus + transType + amount + batchId + batchStatus +
+  std::string tamper_proof_seal = secretKey + transId + transStatus + transType + amount + batchId + batchStatus +
     totalCount + totalAmount + batchUploadId + rebillId + rebillAmount + rebillStatus;
-  std::string result = generateTps(tamper_proof_seal);
-  return result;
+  return md5(tamper_proof_seal);
 }
 
 /// <summary>
@@ -848,7 +847,7 @@ std::string BluePay::setCardTypes()
 /// </summary>
 std::string BluePay::setReceiptTpsString()
 {
-  return this->secretKey + this->accountId + this->receiptFormID + this->returnURL + this->dba + this->amexImage + this->discoverImage + this->receiptTpsDef; 
+  return this->accountId + this->receiptFormID + this->returnURL + this->dba + this->amexImage + this->discoverImage + this->receiptTpsDef + this->receiptTpsHashType;
 }
         
 /// <summary>
@@ -897,7 +896,7 @@ std::string BluePay::addStringProtectedStatus(std::string input)
 /// </summary>
 std::string BluePay::setBp10emuTpsString() 
 {
-  std::string bp10emu = this->secretKey + this->accountId + this->receiptURL + this->receiptURL + this->receiptURL + this->mode + this->transType + this->bp10emuTpsDef;
+  std::string bp10emu = this->accountId + this->receiptURL + this->receiptURL + this->receiptURL + this->mode + this->transType + this->bp10emuTpsDef + this->tpsHashType;
   return addStringProtectedStatus(bp10emu);
 }
 
@@ -906,17 +905,8 @@ std::string BluePay::setBp10emuTpsString()
 /// </summary>
 std::string BluePay::setShpfTpsString() 
 {
-  std::string shpf = this->secretKey + this->shpfFormID + this->accountId + this->dba + this->bp10emuTamperProofSeal + this->amexImage + this->discoverImage + this->bp10emuTpsDef + this->shpfTpsDef; 
+  std::string shpf = this->shpfFormID + this->accountId + this->dba + this->bp10emuTamperProofSeal + this->amexImage + this->discoverImage + this->bp10emuTpsDef + this->tpsHashType + this->shpfTpsDef + this->shpfTpsHashType;
   return addStringProtectedStatus(shpf);
-}
-
-/// <summary>
-/// Generates a Tamperproof Seal for a url. Must be used with GenerateURL.
-/// </summary>
-/// <param name="input"></param>
-std::string BluePay::calcURLTps(std::string input)
-{
-  return md5(input);
 }
 
 /// <summary>
@@ -942,6 +932,31 @@ std::string BluePay::encodeURL(std::string input)
 }
 
 /// <summary>
+/// Decodes a URL into a string.
+/// </summary>
+/// <param name="input"></param>
+std::string BluePay::urlDecode(std::string str){
+    std::string result;
+    char ch;
+    int i, ii, len = str.length();
+    
+    for (i=0; i < len; i++){
+        if(str[i] != '%'){
+            if(str[i] == '+')
+                result += ' ';
+            else
+                result += str[i];
+        }else{
+            sscanf(str.substr(i + 1, 2).c_str(), "%x", &ii);
+            ch = static_cast<char>(ii);
+            result += ch;
+            i = i + 2;
+        }
+    }
+    return result;
+}
+
+/// <summary>
 /// Sets the receipt url or uses the remote url provided. Must be used with GenerateURL.
 /// </summary>
 std::string BluePay::setReceiptURL()
@@ -953,13 +968,14 @@ std::string BluePay::setReceiptURL()
   else 
   {
     output =  "https://secure.bluepay.com/interfaces/shpf?SHPF_FORM_ID=" + this->receiptFormID +
-    "&SHPF_ACCOUNT_ID=" + this->accountId + 
-    "&SHPF_TPS_DEF="    + encodeURL(receiptTpsDef) + 
-    "&SHPF_TPS="        + encodeURL(receiptTamperProofSeal) + 
-    "&RETURN_URL="      + encodeURL(returnURL) +
-    "&DBA="             + encodeURL(dba) + 
-    "&AMEX_IMAGE="      + encodeURL(amexImage) + 
-    "&DISCOVER_IMAGE="  + encodeURL(discoverImage);
+    "&SHPF_ACCOUNT_ID="     + this->accountId + 
+    "&SHPF_TPS_DEF="        + encodeURL(receiptTpsDef) +
+    "&SHPF_TPS_HASH_TYPE="  + encodeURL(receiptTpsHashType) +
+    "&SHPF_TPS="            + encodeURL(receiptTamperProofSeal) + 
+    "&RETURN_URL="          + encodeURL(returnURL) +
+    "&DBA="                 + encodeURL(dba) + 
+    "&AMEX_IMAGE="          + encodeURL(amexImage) + 
+    "&DISCOVER_IMAGE="      + encodeURL(discoverImage);
   }
   return output;
 }
@@ -973,6 +989,7 @@ std::string BluePay::calcURLResponse()
   output += "SHPF_FORM_ID="         + encodeURL(shpfFormID);
   output += "&SHPF_ACCOUNT_ID="     + encodeURL(accountId);
   output += "&SHPF_TPS_DEF="        + encodeURL(shpfTpsDef);
+  output += "&SHPF_TPS_HASH_TYPE="  + encodeURL(shpfTpsHashType);
   output += "&SHPF_TPS="            + encodeURL(shpfTamperProofSeal);
   output += "&MODE="                + encodeURL(mode);
   output += "&TRANSACTION_TYPE="    + encodeURL(transType);
@@ -990,7 +1007,8 @@ std::string BluePay::calcURLResponse()
   output += "&DISCOVER_IMAGE="      + encodeURL(discoverImage);
   output += "&REDIRECT_URL="        + encodeURL(receiptURL);
   output += "&TPS_DEF="             + encodeURL(bp10emuTpsDef);
-  output += "&CARD_TYPES="          + encodeURL(cardTypes);            
+  output += "&TPS_HASH_TYPE="       + encodeURL(tpsHashType);
+  output += "&CARD_TYPES="          + encodeURL(cardTypes);
   return output;           
 }
 
@@ -1035,7 +1053,7 @@ std::string BluePay::calcURLResponse()
 /// <param name="customID2"></param> A merchant defined custom ID 2 value.
 /// <param name="protectCustomID2"></param> Yes/No -- Should the Custom ID 2 value be protected from change using the tamperproof seal?
 /// </summary>
-std::string BluePay::generateURL(std::string merchantName, std::string returnURL, std::string transactionType, std::string acceptDiscover, std::string acceptAmex, std::string amount, std::string protectAmount , std::string paymentTemplate, std::string receiptTemplate, std::string receiptTempRemoteURL, std::string rebilling, std::string rebProtect, std::string rebAmount, std::string rebCycles, std::string rebStartDate, std::string rebFrequency, std::string customID1, std::string protectCustomID1, std::string customID2, std::string protectCustomID2)
+std::string BluePay::generateURL(std::string merchantName, std::string returnURL, std::string transactionType, std::string acceptDiscover, std::string acceptAmex, std::string amount, std::string protectAmount , std::string paymentTemplate, std::string receiptTemplate, std::string receiptTempRemoteURL, std::string rebilling, std::string rebProtect, std::string rebAmount, std::string rebCycles, std::string rebStartDate, std::string rebFrequency, std::string customID1, std::string protectCustomID1, std::string customID2, std::string protectCustomID2, std::string tpsHashType)
 {
   this->dba = merchantName;
   this->returnURL = returnURL;
@@ -1057,18 +1075,37 @@ std::string BluePay::generateURL(std::string merchantName, std::string returnURL
   this->protectCustomID1 = protectCustomID1;
   this->customId2 = customID2;
   this->protectCustomID2 = protectCustomID2;
+  this->shpfTpsHashType = "HMAC_SHA512";
+  this->receiptTpsHashType = this->shpfTpsHashType;
+  this->tpsHashType = setHashType(tpsHashType);
   this->cardTypes = setCardTypes();
-  this->receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF";
+  this->receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE";
   this->receiptTpsString = setReceiptTpsString();
-  this->receiptTamperProofSeal = calcURLTps(this->receiptTpsString);
+  this->receiptTamperProofSeal = generateTps(this->receiptTpsString, this->receiptTpsHashType);
   this->receiptURL = setReceiptURL();
-  this->bp10emuTpsDef = addDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF");
+  this->bp10emuTpsDef = addDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF TPS_HASH_TYPE");
   this->bp10emuTpsString = setBp10emuTpsString();
-  this->bp10emuTamperProofSeal = calcURLTps(this->bp10emuTpsString);
-  this->shpfTpsDef = addDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF SHPF_TPS_DEF");
+  this->bp10emuTamperProofSeal = generateTps(this->bp10emuTpsString, this->tpsHashType);
+  this->shpfTpsDef = addDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF TPS_HASH_TYPE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE");
   this->shpfTpsString = setShpfTpsString();
-  this->shpfTamperProofSeal = calcURLTps(this->shpfTpsString);
+  this->shpfTamperProofSeal = generateTps(this->shpfTpsString, this->shpfTpsHashType);
   return calcURLResponse();
+}
+
+std::string BluePay::setHashType(std::string chosenHash)
+{
+    std::string default_hash = "HMAC_SHA512";
+    std::string result = "";
+    std::transform(chosenHash.begin(), chosenHash.end(),chosenHash.begin(), ::toupper);
+    std::vector<std::string> hashes = {"MD5", "SHA256", "SHA512", "HMAC_SHA256"};
+    if (std::find(hashes.begin(), hashes.end(), chosenHash) != hashes.end())
+    {
+        result = chosenHash;
+    } else {
+        result = default_hash;
+    }
+    
+    return result;
 }
 
 static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp)
@@ -1077,230 +1114,228 @@ static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *use
   return size * nmemb;
 }
 
-std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems) 
+std::vector<std::string> BluePay::split(const std::string &s, char delim, std::vector<std::string> &elems)
 {
-  std::stringstream ss(s);
-  std::string item;
-  while (std::getline(ss, item, delim))  {
-    elems.push_back(item);
-  }
-  return elems;
-}
-
-
-std::vector<std::string> split(const std::string &s, char delim) 
-{
-  std::vector<std::string> elems;
-  split(s, delim, elems);
-  return elems;
-}
-
-char* getResponseField(char *nvp, const char *Name, char *Value) 
-{
-  char *pos1 = strstr(nvp, Name);
-
-  if (pos1) {
-    pos1 += strlen(Name);
-
-    if (*pos1 == '=') {
-      pos1++;
-
-      while (*pos1 && *pos1 != '&') {
-        if (*pos1 == '%') {
-          *Value++ = (char)ToHex(pos1[1]) * 16 + ToHex(pos1[2]);
-          pos1 += 3;
-        } else if (*pos1 == '+') {
-          *Value++ = ' ';
-          pos1++;
-        } else {
-          *Value++ = *pos1++;
-        }
-      }
-
-      *Value++ = '\0';
-      return Value;
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, delim))  {
+        elems.push_back(item);
     }
-  }
-  char * error_string = strdup("Error");
-  return error_string;
+    return elems;
+}
+
+
+std::vector<std::string> BluePay::split(const std::string &s, char delim) 
+{
+    std::vector<std::string> elems;
+    split(s, delim, elems);
+    return elems;
 }
 
 char* BluePay::process()
-{  
+{
     std::string postData = "";
-
-  if (this->api == "bpdailyreport2") {
-    calcReportTps();
-    this->URL = "https://secure.bluepay.com/interfaces/bpdailyreport2";
-    postData += "ACCOUNT_ID=" + this->accountId +
-      "&MODE=" + (this->mode) +
-      "&TAMPER_PROOF_SEAL=" + (this->Tps) +
-      "&REPORT_START_DATE=" + (this->reportStartDate) +
-      "&REPORT_END_DATE=" + (this->reportEndDate) +
-      "&DO_NOT_ESCAPE=" + (this->doNotEscape) +
-      "&QUERY_BY_SETTLEMENT=" + (this->queryBySettlement) +
-      "&QUERY_BY_HIERARCHY=" + (this->queryByHierarchy) +
-      "&TPS_HASH_TYPE=" + (this->tpsHashType) +
-      "&EXCLUDE_ERRORS=" + (this->excludeErrors);
-  // } else if (this->reportStartDate != "") {
-  } else if (this->api == "stq") {
-    calcReportTps();
-    this->URL = "https://secure.bluepay.com/interfaces/stq";
-    postData += "ACCOUNT_ID=" + (this->accountId) +
-      "&MODE=" + (this->mode) +
-      "&TAMPER_PROOF_SEAL=" + (this->Tps) +
-      "&REPORT_START_DATE=" + (this->reportStartDate) +
-      "&REPORT_END_DATE=" + (this->reportEndDate) +
-      "&TPS_HASH_TYPE=" + (this->tpsHashType) +
-      "&EXCLUDE_ERRORS=" + (this->excludeErrors);
-    postData += (this->masterId != "") ? "&id=" + (this->masterId) : "";
-    postData += (this->paymentType != "") ? "&payment_type=" + (this->paymentType) : "";
-    postData += (this->transType != "") ? "&trans_type=" + (this->transType) : "";
-    postData += (this->amount != "") ? "&amount=" + (this->amount) : "";
-    postData += (this->name1 != "") ? "&name1=" + (this->name1) : "";
-    postData += (this->name2 != "") ? "&name2=" + (this->name2) : "";
-  } else if (this->api == "bp10emu") {
-    calcTps();
-    this->URL = "https://secure.bluepay.com/interfaces/bp10emu";
-    postData += "MERCHANT=" + (this->accountId) +
-      "&MODE=" + (this->mode) +
-      "&TRANSACTION_TYPE=" + (this->transType) +
-      "&TAMPER_PROOF_SEAL=" + (this->Tps) +
-      "&NAME1=" + (this->name1) +
-      "&NAME2=" + (this->name2) +
-      "&AMOUNT=" + (this->amount) +
-      "&ADDR1=" + (this->addr1) +
-      "&ADDR2=" + (this->addr2) +
-      "&CITY=" + (this->city) +
-      "&STATE=" + (this->state) +
-      "&ZIPCODE=" + (this->zip) +
-      "&COMMENT=" + (this->memo) +
-      "&PHONE=" + (this->phone) +
-      "&EMAIL=" + (this->email) +
-      "&REBILLING=" + (this->doRebill) +
-      "&REB_FIRST_DATE=" + (this->rebillFirstDate) +
-      "&REB_EXPR=" + (this->rebillExpr) +
-      "&REB_CYCLES=" + (this->rebillCycles) +
-      "&REB_AMOUNT=" + (this->rebillAmount) +
-      "&RRNO=" + (this->masterId) +
-      "&PAYMENT_TYPE=" + (this->paymentType) +
-      "&CUSTOM_ID=" + (this->customId1) +
-      "&CUSTOM_ID2=" + (this->customId2) +
-      "&INVOICE_ID=" + (this->invoiceId) +
-      "&ORDER_ID=" + (this->orderId) +
-      "&AMOUNT_TIP=" + (this->amountTip) +
-      "&AMOUNT_TAX=" + (this->amountTax) +
-      "&AMOUNT_FOOD=" + (this->amountFood) +
-      "&AMOUNT_MISC=" + (this->amountMisc) +
-      "&SWIPE=" + (this->trackData) +
-      "&TPS_HASH_TYPE=" + (this->tpsHashType) +
-      "&RESPONSEVERSION=1"
-      ;
-      // std::cout << postData;
-      
-    if (this->paymentType == "CREDIT") {
-      postData = postData + "&CC_NUM=" + (this->paymentAccount) +
-        "&CC_EXPIRES=" + (this->cardExpire) +
-        "&CVCVV2=" + (this->cvv2);
-    } else {
-      postData = postData + "&ACH_ROUTING=" + (this->routingNum) +
-        "&ACH_ACCOUNT=" + (this->accountNum) +
-        "&ACH_ACCOUNT_TYPE=" + (this->accountType) +
-        "&DOC_TYPE=" + (this->docType);
+    
+    if (this->api == "bpdailyreport2") {
+        calcReportTps();
+        this->URL = "https://secure.bluepay.com/interfaces/bpdailyreport2";
+        postData += "ACCOUNT_ID=" + this->accountId +
+        "&MODE=" + (this->mode) +
+        "&TAMPER_PROOF_SEAL=" + (this->Tps) +
+        "&REPORT_START_DATE=" + (this->reportStartDate) +
+        "&REPORT_END_DATE=" + (this->reportEndDate) +
+        "&DO_NOT_ESCAPE=" + (this->doNotEscape) +
+        "&QUERY_BY_SETTLEMENT=" + (this->queryBySettlement) +
+        "&QUERY_BY_HIERARCHY=" + (this->queryByHierarchy) +
+        "&TPS_HASH_TYPE=" + (this->tpsHashType) +
+        "&EXCLUDE_ERRORS=" + (this->excludeErrors);
+        // } else if (this->reportStartDate != "") {
+    } else if (this->api == "stq") {
+        calcReportTps();
+        this->URL = "https://secure.bluepay.com/interfaces/stq";
+        postData += "ACCOUNT_ID=" + (this->accountId) +
+        "&MODE=" + (this->mode) +
+        "&TAMPER_PROOF_SEAL=" + (this->Tps) +
+        "&REPORT_START_DATE=" + (this->reportStartDate) +
+        "&REPORT_END_DATE=" + (this->reportEndDate) +
+        "&TPS_HASH_TYPE=" + (this->tpsHashType) +
+        "&EXCLUDE_ERRORS=" + (this->excludeErrors);
+        postData += (this->masterId != "") ? "&id=" + (this->masterId) : "";
+        postData += (this->paymentType != "") ? "&payment_type=" + (this->paymentType) : "";
+        postData += (this->transType != "") ? "&trans_type=" + (this->transType) : "";
+        postData += (this->amount != "") ? "&amount=" + (this->amount) : "";
+        postData += (this->name1 != "") ? "&name1=" + (this->name1) : "";
+        postData += (this->name2 != "") ? "&name2=" + (this->name2) : "";
+    } else if (this->api == "bp10emu") {
+        calcTps();
+        this->URL = "https://secure.bluepay.com/interfaces/bp10emu";
+        postData += "MERCHANT=" + (this->accountId) +
+        "&MODE=" + (this->mode) +
+        "&TRANSACTION_TYPE=" + (this->transType) +
+        "&TAMPER_PROOF_SEAL=" + (this->Tps) +
+        "&NAME1=" + (this->name1) +
+        "&NAME2=" + (this->name2) +
+        "&AMOUNT=" + (this->amount) +
+        "&ADDR1=" + (this->addr1) +
+        "&ADDR2=" + (this->addr2) +
+        "&CITY=" + (this->city) +
+        "&STATE=" + (this->state) +
+        "&ZIPCODE=" + (this->zip) +
+        "&COMMENT=" + (this->memo) +
+        "&PHONE=" + (this->phone) +
+        "&EMAIL=" + (this->email) +
+        "&REBILLING=" + (this->doRebill) +
+        "&REB_FIRST_DATE=" + (this->rebillFirstDate) +
+        "&REB_EXPR=" + (this->rebillExpr) +
+        "&REB_CYCLES=" + (this->rebillCycles) +
+        "&REB_AMOUNT=" + (this->rebillAmount) +
+        "&RRNO=" + (this->masterId) +
+        "&PAYMENT_TYPE=" + (this->paymentType) +
+        "&CUSTOM_ID=" + (this->customId1) +
+        "&CUSTOM_ID2=" + (this->customId2) +
+        "&INVOICE_ID=" + (this->invoiceId) +
+        "&ORDER_ID=" + (this->orderId) +
+        "&AMOUNT_TIP=" + (this->amountTip) +
+        "&AMOUNT_TAX=" + (this->amountTax) +
+        "&AMOUNT_FOOD=" + (this->amountFood) +
+        "&AMOUNT_MISC=" + (this->amountMisc) +
+        "&SWIPE=" + (this->trackData) +
+        "&TPS_HASH_TYPE=" + (this->tpsHashType);
+        
+        if (this->paymentType == "CREDIT") {
+            postData = postData + "&CC_NUM=" + (this->paymentAccount) +
+            "&CC_EXPIRES=" + (this->cardExpire) +
+            "&CVCVV2=" + (this->cvv2);
+        } else {
+            postData = postData + "&ACH_ROUTING=" + (this->routingNum) +
+            "&ACH_ACCOUNT=" + (this->accountNum) +
+            "&ACH_ACCOUNT_TYPE=" + (this->accountType) +
+            "&DOC_TYPE=" + (this->docType);
+        }
+    } else if (this->api == "bp20rebadmin"){
+        calcRebillTps();
+        this->URL = "https://secure.bluepay.com/interfaces/bp20rebadmin";
+        postData += "ACCOUNT_ID=" + (this->accountId) +
+        "&TAMPER_PROOF_SEAL=" + (this->Tps) +
+        "&TRANS_TYPE=" + (this->transType) +
+        "&REBILL_ID=" + (this->rebillId) +
+        "&TEMPLATE_ID=" + (this->templateId) +
+        "&REB_EXPR=" + (this->rebillExpr) +
+        "&REB_CYCLES=" + (this->rebillCycles) +
+        "&REB_AMOUNT=" + (this->rebillAmount) +
+        "&NEXT_AMOUNT=" + (this->rebillNextAmount) +
+        "&TPS_HASH_TYPE=" + (this->tpsHashType) +
+        "&STATUS=" + (this->rebillStatus);
     }
-  } else if (this->api == "bp20rebadmin"){
-    calcRebillTps();
-    this->URL = "https://secure.bluepay.com/interfaces/bp20rebadmin";
-    postData += "ACCOUNT_ID=" + (this->accountId) +
-      "&TAMPER_PROOF_SEAL=" + (this->Tps) +
-      "&TRANS_TYPE=" + (this->transType) +
-      "&REBILL_ID=" + (this->rebillId) +
-      "&TEMPLATE_ID=" + (this->templateId) +
-      "&REB_EXPR=" + (this->rebillExpr) +
-      "&REB_CYCLES=" + (this->rebillCycles) +
-      "&REB_AMOUNT=" + (this->rebillAmount) +
-      "&NEXT_AMOUNT=" + (this->rebillNextAmount) +
-      "&TPS_HASH_TYPE=" + (this->tpsHashType) +
-      "&STATUS=" + (this->rebillStatus);
-  }
-  // Add Level 2 data, if available.
-  for( auto field : level2Info )
-  {
-    postData += "&" + field.first + "=" + field.second;
-  }
-
-  // Add Level 3 item data, if available.
-  for( auto item : lineItems )
-  {
-    for( auto field : item )
+    // Add Response version to return
+    postData += "&RESPONSEVERSION=1";
+    
+    // Add Level 2 data, if available.
+    for( auto field : level2Info )
     {
         postData += "&" + field.first + "=" + field.second;
     }
-  }
     
-  //Create HTTPS POST object and send to BluePay
-  CURL *curl;
-  CURLcode res;
-  std::string readBuffer;
-  curl_global_init(CURL_GLOBAL_ALL);
-  char *postToBp = (char*)postData.c_str();
+    // Add Level 3 item data, if available.
+    for( auto item : lineItems )
+    {
+        for( auto field : item )
+        {
+            postData += "&" + field.first + "=" + field.second;
+        }
+    }
+    
+    //Create HTTPS POST object and send to BluePay
+    CURL *curl;
+    CURLcode res;
+    std::string readBuffer;
+    curl_global_init(CURL_GLOBAL_ALL);
+    char *postToBp = (char*)postData.c_str();
+    
+    curl = curl_easy_init();
+    if (curl) {
+        curl_easy_setopt(curl, CURLOPT_URL, this->URL.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postToBp);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0);
+        if (this->URL == "https://secure.bluepay.com/interfaces/bp10emu") {
+            curl_easy_setopt(curl, CURLOPT_HEADER, 1);
+        }
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+        
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                    curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+    }
+    curl_global_cleanup();
+    std::istringstream stream(readBuffer);
+    std::string line;
+    //std::cout << readBuffer;
+    while (std::getline(stream, line))  {
+        if (line.find("Location") == 0) {
+            std::vector<std::string> nvp = split(line, '?');
+            this->queryResponse = (char*)nvp[1].c_str();
+            
+            std::string responseString = urlDecode(queryResponse);
+            this->responseFields = mapResponsePairs(responseString);
+            
+            std::strcpy(result, responseFields["Result"].c_str());
+            std::strcpy(message, responseFields["MESSAGE"].c_str());
+            std::strcpy(transId, responseFields["TRANS_ID"].c_str());
+            std::strcpy(cvv2Response, responseFields["CVV2_RESULT"].c_str());
+            std::strcpy(avsResponse, responseFields["AVS_RESULT"].c_str());
+            std::strcpy(maskedAccount, responseFields["PAYMENT_ACCOUNT"].c_str());
+            std::strcpy(cardType, responseFields["CARD_TYPE"].c_str());
+            std::strcpy(bank, responseFields["BANK_NAME"].c_str());
+            std::strcpy(authCode, responseFields["AUTH_CODE"].c_str());
+            std::strcpy(rebId, responseFields["REBID"].c_str());
+            break;
+        } else if (this->URL != "https://secure.bluepay.com/interfaces/bp10emu") {
+            queryResponse = (char*)line.c_str();
+            std::string responseString = urlDecode(queryResponse);
+            this->responseFields = mapResponsePairs(responseString);
+            
+            std::strcpy(rebId, responseFields["rebill_id"].c_str());
+            std::strcpy(rebStatus, responseFields["status"].c_str());
+            std::strcpy(rebCreationDate, responseFields["creation_date"].c_str());
+            std::strcpy(rebNextDate, responseFields["next_date"].c_str());
+            std::strcpy(rebLastDate, responseFields["last_date"].c_str());
+            std::strcpy(rebSchedExpr, responseFields["sched_expr"].c_str());
+            std::strcpy(rebCyclesRemaining, responseFields["cycles_remain"].c_str());
+            std::strcpy(rebAmount, responseFields["reb_amount"].c_str());
+            std::strcpy(rebNextAmount, responseFields["next_amount"].c_str());
+            break;
+        }
+    }
+    this->response = readBuffer;
+    //std::cout << "response:" + this->getResponse();
+    return getMessage();
+}
 
-  curl = curl_easy_init();
-  if (curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, this->URL.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postToBp);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0);
-    if (this->URL == "https://secure.bluepay.com/interfaces/bp10emu") {
-      curl_easy_setopt(curl, CURLOPT_HEADER, 1);
+/// <summary>
+/// Returns Map of Response Pairs
+/// </summary>
+/// <returns></returns>
+std::map<std::string, std::string> BluePay::mapResponsePairs(std::string responseString)
+{
+    std::map<std::string, std::string> responsePairs = {};
+    std::vector<std::string> pairStrings = split(responseString, '&');
+    std::vector<std::string> kvStrings;
+    std::string key;
+    std::string value = "";
+    for (std::string pair : pairStrings) {
+        kvStrings = split(pair, '=');
+        key = kvStrings[0];
+        if (1 < kvStrings.size()) {
+            value = kvStrings[1];
+        }
+        responsePairs.insert({key, value});
     }
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
-
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n",
-      curl_easy_strerror(res));
-    }
-    curl_easy_cleanup(curl);
-  }
-  curl_global_cleanup();
-  std::istringstream stream(readBuffer);
-  std::string line;
-  //std::cout << readBuffer;
-  while (std::getline(stream, line))  {
-    if (line.find("Location") == 0) {
-      std::vector<std::string> nvp = split(line, '?');
-      queryResponse = (char*)nvp[1].c_str();
-      getResponseField(queryResponse, "Result", result);
-      getResponseField(queryResponse, "MESSAGE", message);
-      getResponseField(queryResponse, "TRANS_ID", transId);
-      getResponseField(queryResponse, "CVV2_RESULT", cvv2Response);
-      getResponseField(queryResponse, "AVS_RESULT", avsResponse);
-      getResponseField(queryResponse, "PAYMENT_ACCOUNT", maskedAccount);
-      getResponseField(queryResponse, "CARD_TYPE", cardType);
-      getResponseField(queryResponse, "BANK_NAME", bank);
-      getResponseField(queryResponse, "AUTH_CODE", authCode);
-      getResponseField(queryResponse, "REBID", rebId);
-      break;
-    } else if (this->URL != "https://secure.bluepay.com/interfaces/bp10emu") {
-      std::vector<std::string> nvp = split(line, '?');
-      queryResponse = (char*)line.c_str();
-      getResponseField(queryResponse, "rebill_id", rebId);
-      getResponseField(queryResponse, "status", rebStatus);
-      getResponseField(queryResponse, "creation_date", rebCreationDate);
-      getResponseField(queryResponse, "next_date", rebNextDate);
-      getResponseField(queryResponse, "last_date", rebLastDate);
-      getResponseField(queryResponse, "sched_expr", rebSchedExpr);
-      getResponseField(queryResponse, "cycles_remain", rebCyclesRemaining);
-      getResponseField(queryResponse, "reb_amount", rebAmount);
-      getResponseField(queryResponse, "next_amount", rebNextAmount);
-      break;
-    }
-  }
-  this->response = readBuffer;
-  //std::cout << "response:" + this->getResponse();
-  return getMessage();
+    return responsePairs;
 }
 
 /// <summary>

--- a/C++/bluepay-cpp/BluePay.h
+++ b/C++/bluepay-cpp/BluePay.h
@@ -28,7 +28,7 @@ private:
   std::string secretKey;
   std::string mode;
 
-  std::string tpsHashType = "MD5";
+  std::string tpsHashType = "HMAC_SHA512";
 
   // required for auth or sale
   std::string paymentAccount;

--- a/C++/bluepay-cpp/BluePay.h
+++ b/C++/bluepay-cpp/BluePay.h
@@ -220,9 +220,6 @@ public:
   void calcTps();
   void calcRebillTps();
   void calcReportTps();
-  static std::string calcTransNotifyTps(std::string secretKey, std::string transId, std::string transStatus, std::string transType,
-    std::string amount, std::string batchId, std::string batchStatus, std::string totalCount, std::string totalAmount,
-    std::string batchUploadId, std::string rebillId, std::string rebillAmount, std::string rebillStatus);
 
   std::string setCardTypes();
   std::string setReceiptTpsString();

--- a/C++/bluepay-cpp/BluePay.h
+++ b/C++/bluepay-cpp/BluePay.h
@@ -106,6 +106,8 @@ private:
   std::string shpfFormID;
   std::string receiptFormID;
   std::string remoteURL;
+  std::string shpfTpsHashType;
+  std::string receiptTpsHashType;
   std::string cardTypes;
   std::string receiptTpsDef;
   std::string receiptTpsString;
@@ -122,6 +124,7 @@ private:
 
   char *queryResponse;
   std::string response;
+  std::map<std::string, std::string> responseFields;
   char result[128];
   char message[128];
   char transId[16];
@@ -213,11 +216,11 @@ public:
   void setPhone(std::string phone);
   void setEmail(std::string email);
 
-  std::string generateTps(std::string message);
+  std::string generateTps(std::string message, std::string hashType);
   void calcTps();
   void calcRebillTps();
   void calcReportTps();
-  static std::string calcTransNotifyTps(std::string transId, std::string transStatus, std::string transType,
+  static std::string calcTransNotifyTps(std::string secretKey, std::string transId, std::string transStatus, std::string transType,
     std::string amount, std::string batchId, std::string batchStatus, std::string totalCount, std::string totalAmount,
     std::string batchUploadId, std::string rebillId, std::string rebillAmount, std::string rebillStatus);
 
@@ -226,16 +229,21 @@ public:
   std::string calcURLTps(std::string);
   std::string setReceiptURL();
   std::string encodeURL(std::string);
+  std::string urlDecode(std::string);
   std::string addStringProtectedStatus(std::string);
   std::string addDefProtectedStatus(std::string);
   std::string setBp10emuTpsString();
   std::string setShpfTpsString();
   std::string calcURLResponse(); 
-  std::string generateURL(std::string merchantName, std::string returnURL, std::string transactionType, std::string acceptDiscover, std::string acceptAmex, std::string amount, std::string protectAmount , std::string paymentTemplate = "mobileform01", std::string receiptTemplate = "mobileresult01", std::string receiptTempRemoteURL = "", std::string rebilling = "No", std::string rebProtect = "Yes", std::string rebAmount = "", std::string rebCycles = "", std::string rebStartDate = "", std::string rebFrequency = "", std::string customID1 = "", std::string protectCustomID1 = "No", std::string customID2 = "", std::string protectCustomID2 = "No");
+  std::string generateURL(std::string merchantName, std::string returnURL, std::string transactionType, std::string acceptDiscover, std::string acceptAmex, std::string amount, std::string protectAmount , std::string paymentTemplate = "mobileform01", std::string receiptTemplate = "mobileresult01", std::string receiptTempRemoteURL = "", std::string rebilling = "No", std::string rebProtect = "Yes", std::string rebAmount = "", std::string rebCycles = "", std::string rebStartDate = "", std::string rebFrequency = "", std::string customID1 = "", std::string protectCustomID1 = "No", std::string customID2 = "", std::string protectCustomID2 = "No", std::string tpsHashType = "");
+  std::string setHashType(std::string chosenHash);
 
   void addHeader(const std::string& s);
   size_t rcvHeaders(void *buffer, size_t size, size_t nmemb, void *userp);
+  std::vector<std::string> split(const std::string &s, char delim);
+  std::vector<std::string> split(const std::string &s, char delim, std::vector<std::string> &elems);
   char* process();
+  std::map<std::string, std::string> mapResponsePairs(std::string responseString);
   std::string getResponse();
   char* getResult();
   char* getTransId();
@@ -260,4 +268,3 @@ public:
 
 
 };
-

--- a/C++/bluepay-cpp/main.cpp
+++ b/C++/bluepay-cpp/main.cpp
@@ -13,6 +13,7 @@
 // #include "../Get_Data/Retrieve_Settlement_Data.h"
 // #include "../Get_Data/Retrieve_Transaction_Data.h"
 // #include "../Get_Data/Single_Transaction_Query.h"
+// #include "../Get_Data/Validate_BP_Stamp.h"
 
 // #include "../Rebill/Cancel_Recurring_Payment.h"
 // #include "../Rebill/Create_Recurring_Payment_ACH.h"
@@ -41,6 +42,7 @@ int main(int argc, const char * argv[]) {
 	// retrieveSettlementData();
 	// retrieveTransactionData();
 	// singleTransactionQuery();
+	// validateBPStamp();
 
 	// cancelRecurringPayment();
 	// createRecurringPaymentACH();

--- a/Java/src/BluePay.java
+++ b/Java/src/BluePay.java
@@ -1084,7 +1084,7 @@ public class BluePay
   public HashMap<String,String> process() throws ClientProtocolException, IOException, NoSuchAlgorithmException {
     List <NameValuePair> nameValuePairs = new ArrayList <NameValuePair>();
 	  nameValuePairs.add(new BasicNameValuePair("MODE", BP_MODE));
-    nameValuePairs.add(new BasicNameValuePair("RESPONSEVERSION", "1")); 
+    nameValuePairs.add(new BasicNameValuePair("RESPONSEVERSION", "5")); 
 	  if (API.equals("bpdailyreport2")) {
   		  BP_URL = "https://secure.bluepay.com/interfaces/bpdailyreport2";
   		  nameValuePairs.add(new BasicNameValuePair("ACCOUNT_ID", BP_MERCHANT));

--- a/Java/src/BluePay.java
+++ b/Java/src/BluePay.java
@@ -70,7 +70,7 @@ public class BluePay
   private String CUSTOM_ID2 = "";
   private String ORDER_ID = "";
   private String INVOICE_ID = "";
-  private String TPS_HASH_TYPE = "MD5";
+  private String TPS_HASH_TYPE = "HMAC_SHA512";
   
   // rebilling parameters
   private String REBILLING = "0";

--- a/Java/src/get_data/Transaction_Notification.java
+++ b/Java/src/get_data/Transaction_Notification.java
@@ -34,35 +34,29 @@ public class Transaction_Notification extends HttpServlet {
     String TRANS_STATUS = request.getParameter("trans_status");
     String TRANS_TYPE = request.getParameter("trans_type");
     String AMOUNT = request.getParameter("amount");
-    String BATCH_ID = request.getParameter("batch_id");
-    String BATCH_STATUS = request.getParameter("batch_status");
-    String TOTAL_COUNT = request.getParameter("total_count");
-    String TOTAL_AMOUNT = request.getParameter("total_amount");
-    String BATCH_UPLOAD_ID = request.getParameter("batch_upload_id");
     String REBILL_ID = request.getParameter("rebill_id");
     String REBILL_AMOUNT = request.getParameter("reb_amount");
     String REBILL_STATUS = request.getParameter("status");
-
+    String TPS_HASH_TYPE = request.getParameter("TPS_HASH_TYPE");
+    String BP_STAMP = request.getParameter("BP_STAMP");
+    String BP_STAMP_DEF = request.getParameter("BP_STAMP_DEF");
+ 
     // calculate expected bp_stamp
-    String bpStamp;
+    String bpStampString = "";
+    String[] bpStampFields = BP_STAMP_DEF.split("%20");
+    for (String field : bpStampFields) {
+      bpStampString += request.getParameter(field);
+    }
+    bpStampString = java.net.URLDecoder.decode(bpStampString, "UTF-8");
+    String expectedStamp = "";
     try { 
-      bpStamp = tps.calcTransNotifyTPS(
-        SECRET_KEY,
-        TRANS_ID,
-        TRANS_STATUS,
-        TRANS_TYPE,
-        AMOUNT,
-        BATCH_ID,
-        BATCH_STATUS,
-        TOTAL_COUNT,
-        TOTAL_AMOUNT,
-        BATCH_UPLOAD_ID,
-        REBILL_ID,
-        REBILL_AMOUNT,
-        REBILL_STATUS);
-
+        expectedStamp = tps.generateTPS(bpStampString, TPS_HASH_TYPE).toUpperCase();
+    } catch (NoSuchAlgorithmException e) { 
+      e.printStackTrace(); 
+    }
+    
     // check if expected bp_stamp = actual bp_stamp
-    if (bpStamp == request.getParameter("bp_stamp")) {
+    if (expectedStamp == BP_STAMP) {
     // output response
       System.out.println("Transaction ID: " + TRANS_ID);
       System.out.println("Transaction Status: " + TRANS_STATUS);
@@ -74,8 +68,5 @@ public class Transaction_Notification extends HttpServlet {
     } else {
         System.out.println("ERROR IN RECEIVING DATA FROM BLUEPAY");
     }
-  } catch (NoSuchAlgorithmException e) { 
-      e.printStackTrace(); 
-  }
   }
 }

--- a/Java/src/get_data/Validate_BP_Stamp.java
+++ b/Java/src/get_data/Validate_BP_Stamp.java
@@ -1,0 +1,68 @@
+/**
+* BluePay Java Sample code.
+*
+* This code sample reads the values from a BP10emu redirect
+* and authenticates the message using the the BP_STAMP
+* provided in the response. Point the REDIRECT_URL of your 
+* BP10emu request to the location of this script on your server.
+*
+*/
+
+package get_data;
+import bluepay.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+
+@WebServlet("/validateBPStamp")
+public class ValidBPStamp extends HttpServlet {
+  private static final long serialVersionUID = 1L;
+
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    PrintWriter pw = response.getWriter();
+    String ACCOUNT_ID = "Merchant's Account ID Here";
+    String SECRET_KEY = "Merchant's Secret Key Here";
+    String MODE = "TEST";
+    
+    Map<String, String[]> responseParams = request.getParameterMap();
+    
+    if(responseParams.containsKey("BP_STAMP")) { // Check whether BP_STAMP is provided
+        BluePay bp = new BluePay(
+                ACCOUNT_ID,
+                SECRET_KEY,
+                MODE);
+        
+        String bpStampString = "";
+        String[] bpStampFields = responseParams.get("BP_STAMP_DEF")[0].split(" "); // Split BP_STAMP_DEF on whitespace
+        for (String field : bpStampFields) {;
+            bpStampString += responseParams.get(field)[0]; // Concatenate values used to calculate expected BP_STAMP
+        }
+        String expectedStamp = "";
+        try { 
+            expectedStamp = bp.generateTPS(bpStampString, responseParams.get("TPS_HASH_TYPE")[0]).toUpperCase(); // Calculate expected BP_STAMP using hash function specified in response
+        } catch (NoSuchAlgorithmException e) { 
+          e.printStackTrace(); 
+        }
+        if (expectedStamp.equals(responseParams.get("BP_STAMP")[0])) { // Compare expected BP_STAMP with received BP_STAMP
+            // Validate BP_STAMP and reads the response results
+            pw.print("VALID BP_STAMP: TRUE\n");
+            for (Map.Entry<String, String[]> param : responseParams.entrySet()) {
+              pw.print(param.getKey() + ": " + param.getValue()[0] + "\n");
+            }
+        } else {
+            pw.print("ERROR: BP_STAMP VALUES DO NOT MATCH\n");
+        }
+    } else {
+      pw.print("ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION\n");
+    }
+  }
+}

--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -102,7 +102,7 @@ class BluePay {
     private $rebid;
 
     private $postURL;
-    private $tpsHashType = "MD5";
+    private $tpsHashType = "HMAC_SHA512";
 
     // Level 2 processing field
     private $level2Info;

--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -742,7 +742,7 @@ class BluePay {
 
     public function process() {
         $post["MODE"] = $this->mode;
-        $post["RESPONSEVERSION"] = '1'; # Response version to be returned
+        $post["RESPONSEVERSION"] = '5'; # Response version to be returned
         // Case Statement based on which api is used
         switch ($this->api) {
             case "bp10emu":

--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -506,10 +506,10 @@ class BluePay {
     }
 
     // Functions for calculating the TAMPER_PROOF_SEAL
-    public final function createTPSHash($string) {
+    public final function createTPSHash($string, $hashType) {
         $hash = "";
 
-        switch ($this->tpsHashType) {
+        switch ($hashType) {
             case "HMAC_SHA256":
                 $hash = hash_hmac("sha256", $string, $this->secretKey);
                 break;
@@ -532,24 +532,17 @@ class BluePay {
     public final function calcTPS() {
         $tpsString = $this->accountID . $this->transType . $this->amount . $this->doRebill . $this->rebillFirstDate .
         $this->rebillExpr . $this->rebillCycles . $this->rebillAmount . $this->masterID . $this->mode;
-        return $this->createTPSHash($tpsString);
+        return $this->createTPSHash($tpsString, $this->tpsHashType);
     }
 
     public final function calcRebillTPS() {
         $tpsString = $this->accountID . $this->transType . $this->rebillID;
-        return $this->createTPSHash($tpsString);
+        return $this->createTPSHash($tpsString, $this->tpsHashType);
     }
 
     public final function calcReportTPS() {
         $tpsString = $this->accountID . $this->reportStartDate . $this->reportEndDate;
-        return $this->createTPSHash($tpsString);
-    }
-
-    public static final function calcTransNotifyTPS($transID, $transStatus, $transType, $amount, $batchID, $batchStatus, 
-        $totalCount, $totalAmount, $batchUploadID, $rebillID, $rebillAmount, $rebillStatus) {
-        $tpsString = $transID + $transStatus + $transType + $amount + $batchID + $batchStatus + $totalCount +
-        $totalAmount + $batchUploadID + $rebillID + $rebillAmount + $rebillStatus;
-        return $this->createTPSHash($tpsString);
+        return $this->createTPSHash($tpsString, $this->tpsHashType);
     }
 
     // Required arguments for generate_url:
@@ -612,19 +605,36 @@ class BluePay {
         $this->shpfFormID = empty($params['paymentTemplate']) ? 'mobileform01' : $params['paymentTemplate'];
         $this->receiptFormID = empty($params['receiptTemplate']) ? 'mobileresult01' : $params['receiptTemplate'];
         $this->remoteURL = empty($params['receiptTempRemoteURL']) ? '' : $params['receiptTempRemoteURL'];
+        $this->shpfTpsHashType = 'HMAC_SHA512';
+        $this->receiptTpsHashType = $this->shpfTpsHashType;
+        $this->tpsHashType = $this->setHashType($params['TpsHashType'] ?? '');
         $this->cardTypes = $this->setCardTypes();
-        $this->receiptTpsDef = 'SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF';
+        $this->receiptTpsDef = 'SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE';
         $this->receiptTpsString = $this->setReceiptTpsString();
-        $this->receiptTamperProofSeal = $this->calcURLTps($this->receiptTpsString);
+        $this->receiptTamperProofSeal = $this->createTPSHash($this->receiptTpsString, $this->receiptTpsHashType);
         $this->receiptURL = $this->setReceiptURL();
-        $this->bp10emuTpsDef = $this->addDefProtectedStatus('MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF');
+        $this->bp10emuTpsDef = $this->addDefProtectedStatus('MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF TPS_HASH_TYPE');
         $this->bp10emuTpsString = $this->setBp10emuTpsString();
-        $this->bp10emuTamperProofSeal = $this->calcURLTps($this->bp10emuTpsString);
-        $this->shpfTpsDef = $this->addDefProtectedStatus('SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF SHPF_TPS_DEF');
+        $this->bp10emuTamperProofSeal = $this->createTPSHash($this->bp10emuTpsString, $this->tpsHashType);
+        $this->shpfTpsDef = $this->addDefProtectedStatus('SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF TPS_HASH_TYPE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE');
         $this->shpfTpsString = $this->setShpfTpsString();
-        $this->shpfTamperProofSeal = $this->calcURLTps($this->shpfTpsString);
+        $this->shpfTamperProofSeal = $this->createTPSHash($this->shpfTpsString, $this->shpfTpsHashType);
         return $this->calcURLResponse();
     }
+
+    // Validates hash type or returns default
+    public function setHashType($chosen_hash) {
+        $default_hash = 'HMAC_SHA512';
+        $chosen_hash = strtoupper($chosen_hash);
+        $result = '';
+        if ( in_array($chosen_hash, array('MD5', 'SHA256', 'SHA512', 'HMAC_SHA256')) ){
+            $result = $chosen_hash;
+        } else {
+            $result = $default_hash;
+        }
+        return $result;
+    }
+
     // Sets the types of credit card images to use on the Simple Hosted Payment Form. Must be used with generateURL.
     public function setCardTypes() {
         $creditCards = 'vi-mc';
@@ -635,18 +645,18 @@ class BluePay {
 
     // Sets the receipt Tamperproof Seal string. Must be used with generateURL.
     public function setReceiptTpsString() {
-        return $this->secretKey . $this->accountID . $this->receiptFormID. $this->returnURL . $this->dba . $this->amexImage . $this->discoverImage . $this->receiptTpsDef; 
+        return $this->accountID . $this->receiptFormID. $this->returnURL . $this->dba . $this->amexImage . $this->discoverImage . $this->receiptTpsDef . $this->receiptTpsHashType; 
     }
 
     // Sets the bp10emu string that will be used to create a Tamperproof Seal. Must be used with generateURL.
     public function setBp10emuTpsString() {
-        $bp10emu = $this->secretKey . $this->accountID . $this->receiptURL . $this->receiptURL . $this->receiptURL . $this->mode . $this->transType . $this->bp10emuTpsDef;
+        $bp10emu = $this->accountID . $this->receiptURL . $this->receiptURL . $this->receiptURL . $this->mode . $this->transType . $this->bp10emuTpsDef . $this->tpsHashType;
         return $this->addStringProtectedStatus($bp10emu);
     }
 
     // Sets the Simple Hosted Payment Form string that will be used to create a Tamperproof Seal. Must be used with generateURL.
     public function setShpfTpsString() {
-        $shpf = $this->secretKey . $this->shpfFormID . $this->accountID . $this->dba . $this->bp10emuTamperProofSeal . $this->amexImage . $this->discoverImage . $this->bp10emuTpsDef . $this->shpfTpsDef; 
+        $shpf = $this->shpfFormID . $this->accountID . $this->dba . $this->bp10emuTamperProofSeal . $this->amexImage . $this->discoverImage . $this->bp10emuTpsDef . $this->tpsHashType . $this->shpfTpsDef . $this->shpfTpsHashType; 
         return $this->addStringProtectedStatus($shpf);
     }
 
@@ -656,13 +666,14 @@ class BluePay {
             return $this->remoteURL;
         } else {
             return 'https://secure.bluepay.com/interfaces/shpf?SHPF_FORM_ID=' . $this->receiptFormID. 
-            '&SHPF_ACCOUNT_ID=' . $this->accountID . 
-            '&SHPF_TPS_DEF='    . $this->encodeURL($this->receiptTpsDef) . 
-            '&SHPF_TPS='        . $this->encodeURL($this->receiptTamperProofSeal) . 
-            '&RETURN_URL='      . $this->encodeURL($this->returnURL) .
-            '&DBA='             . $this->encodeURL($this->dba) . 
-            '&AMEX_IMAGE='      . $this->encodeURL($this->amexImage) . 
-            '&DISCOVER_IMAGE='  . $this->encodeURL($this->discoverImage);
+            '&SHPF_ACCOUNT_ID='       . $this->accountID . 
+            '&SHPF_TPS_DEF='          . $this->encodeURL($this->receiptTpsDef) . 
+            '&SHPF_TPS_HASH_TYPE='    . $this->encodeURL($this->receiptTpsHashType) . 
+            '&SHPF_TPS='              . $this->encodeURL($this->receiptTamperProofSeal) . 
+            '&RETURN_URL='            . $this->encodeURL($this->returnURL) .
+            '&DBA='                   . $this->encodeURL($this->dba) . 
+            '&AMEX_IMAGE='            . $this->encodeURL($this->amexImage) . 
+            '&DISCOVER_IMAGE='        . $this->encodeURL($this->discoverImage);
         }
     }
 
@@ -700,11 +711,6 @@ class BluePay {
         return $encodedString;
     }
 
-    // Generates a Tamperproof Seal for a url. Must be used with generateURL.
-    public final function calcURLTps($tpsType) {
-        return bin2hex(md5($tpsType, true));
-    }
-
     // Generates the final url for the Simple Hosted Payment Form. Must be used with generateURL.
     public function calcURLResponse() {
         return                  
@@ -712,6 +718,7 @@ class BluePay {
         'SHPF_FORM_ID='         . $this->encodeURL($this->shpfFormID)               .
         '&SHPF_ACCOUNT_ID='     . $this->encodeURL($this->accountID)                .
         '&SHPF_TPS_DEF='        . $this->encodeURL($this->shpfTpsDef)               .
+        '&SHPF_TPS_HASH_TYPE='  . $this->encodeURL($this->shpfTpsHashType)          .
         '&SHPF_TPS='            . $this->encodeURL($this->shpfTamperProofSeal)      .
         '&MODE='                . $this->encodeURL($this->mode)                     .
         '&TRANSACTION_TYPE='    . $this->encodeURL($this->transType)                .
@@ -729,11 +736,13 @@ class BluePay {
         '&DISCOVER_IMAGE='      . $this->encodeURL($this->discoverImage)            .
         '&REDIRECT_URL='        . $this->encodeURL($this->receiptURL)               .
         '&TPS_DEF='             . $this->encodeURL($this->bp10emuTpsDef)            .
+        '&TPS_HASH_TYPE='       . $this->encodeURL($this->tpsHashType)              .
         '&CARD_TYPES='          . $this->encodeURL($this->cardTypes);
     }
 
     public function process() {
         $post["MODE"] = $this->mode;
+        $post["RESPONSEVERSION"] = '1'; # Response version to be returned
         // Case Statement based on which api is used
         switch ($this->api) {
             case "bp10emu":
@@ -897,6 +906,11 @@ class BluePay {
         $this->paymentType = isset($payment_type) ? $payment_type : null;
         $this->transType = isset($trans_type) ? $trans_type : null;
         $this->amount = isset($amount) ? $amount : null;
+
+        /* BP Stamp response parameters */
+        $this->bpStamp = isset($BP_STAMP) ? $BP_STAMP : null;
+        $this->bpStampDef = isset($BP_STAMP_DEF) ? $BP_STAMP_DEF : null;
+        $this->tpsHashType = isset($TPS_HASH_TYPE) ? $TPS_HASH_TYPE : null;
     }
 
     public function getResponse() { return $this->response; }
@@ -929,6 +943,7 @@ class BluePay {
     public function getPaymentType() { return $this->paymentType; }
     public function getTransType() { return $this->transType; }
     public function getAmount() { return $this->amount; }
+
 
     // Returns true if the transaction was approved and not a duplicate
     public function isSuccessfulResponse() {

--- a/PHP/Get_Data/Transaction_Notification.php
+++ b/PHP/Get_Data/Transaction_Notification.php
@@ -10,42 +10,43 @@
 
 include('../BluePay.php');
 
-$secretKey = '';
+$accountID = "Merchant's Account ID Here";
+$secretKey = "Merchant's Secret Key Here";
+$mode = "TEST";
+
+$tps = new BluePay(
+    $accountID,
+    $secretKey,
+    $mode
+);
 
 // get POST parameters
 $transID = isset($_REQUEST['trans_id']) ? $_REQUEST['trans_id'] : null;
 $transStatus = isset($_REQUEST['trans_status']) ? $_REQUEST['trans_status'] : null;
 $transType = isset($_REQUEST['trans_type']) ? $_REQUEST['trans_type'] : null;
 $amount = isset($_REQUEST['amount']) ? $_REQUEST['amount'] : null;
-$batchID = isset($_REQUEST['batch_id']) ? $_REQUEST['batch_id'] : null;
-$batchStatus = isset($_REQUEST['batch_status']) ? $_REQUEST['batch_status'] : null;
-$totalCount = isset($_REQUEST['total_count']) ? $_REQUEST['total_count'] : null;
-$totalAmount = isset($_REQUEST['total_amount']) ? $REQUEST['total_amount'] : null;
-$batchUploadID = isset($_REQUEST['bupload_id']) ? $REQUEST['bupload_id'] : null;
 $rebillID = isset($_REQUEST['rebill_id']) ? $_REQUEST['rebill_id'] : null;
 $rebillAmount = isset($_REQUEST['reb_amount']) ? $_REQUEST['reb_amount'] : null;
 $rebillStatus = isset($_REQUEST['status']) ? $_REQUEST['status'] : null;
+$bpStamp = isset($_REQUEST['BP_STAMP']) ? $_REQUEST['BP_STAMP'] : null;
+$bpStampDef = isset($_REQUEST['BP_STAMP_DEF']) ? $_REQUEST['BP_STAMP_DEF'] : null;
+$tpsHashType = isset($_REQUEST['TPS_HASH_TYPE']) ? $_REQUEST['TPS_HASH_TYPE'] : null;
 
 // calculate expected bp_stamp
-$bpStamp = BluePay::calcTransNotifyTPS(
-    $secretKey,
-    $transID,
-    $transStatus,
-    $transType,
-    $amount,
-    $batchID,
-    $batchStatus,
-    $totalCount,
-    $totalAmount,
-    $batchUploadID,
-    $rebillID,
-    $rebillAmount,
-    $rebillStatus);
+$bpStampFields = explode(' ', $bpStampDef); // Split BP_STAMP_DEF on whitespace
+$bpStampString = '';
+
+$fieldValue = '';
+foreach ($bpStampFields as $field) {
+    $fieldValue = isset($_REQUEST[$field]) ? $_REQUEST[$field] : null;
+    $bpStampString .= $fieldValue; // Concatenate values used to calculate expected BP_STAMP
+}
+$expectedStamp = $tps->createTPSHash($bpStampString, $tpsHashType);
 
 // check if expected bp_stamp = actual bp_stamp
-if (isset($_REQUEST['bp_stamp'])) {
+if (!empty($bpStamp)) {
 
-    if ($bpStamp == $_REQUEST['bp_stamp']) {
+    if ($bpStamp == $expectedStamp) {
 
         // Read response from BluePay
         echo 'Transaction ID: ' . $transID . '<br />' .

--- a/PHP/Get_Data/Validate_BP_Stamp.php
+++ b/PHP/Get_Data/Validate_BP_Stamp.php
@@ -1,0 +1,47 @@
+<?php
+/**
+* BluePay PHP Sample code.
+*
+* This code sample reads the values from a BP10emu redirect
+* and authenticates the message using the the BP_STAMP
+* provided in the response. Point the REDIRECT_URL of your 
+* BP10emu request to the location of this script on your server.
+*/
+
+include('BluePay.php');
+
+$accountID = "Merchant's Account ID Here";
+$secretKey = "Merchant's Secret Key Here";
+$mode = "TEST";
+
+if (array_key_exists('BP_STAMP', $_REQUEST)) { // Check whether BP_STAMP is provided
+    
+    $bp = new BluePay(
+        $accountID,
+        $secretKey,
+        $mode
+    );
+    
+    $bpStampFields = explode(' ', $_REQUEST['BP_STAMP_DEF']); // Split BP_STAMP_DEF on whitespace
+    
+    // Concatenate values used to calculate expected BP_STAMP
+    $bpStampString = '';
+    foreach ($bpStampFields as $field) {
+        $bpStampString .= $_REQUEST[$field];
+    }
+    
+    $expectedStamp = strtoupper( $bp->createTPSHash($bpStampString, $_REQUEST['TPS_HASH_TYPE']) ); // Calculate expected BP_STAMP using hash function specified in response
+    
+    if ($expectedStamp == $_REQUEST['BP_STAMP']) { // Compare expected BP_STAMP with received BP_STAMP
+        // Validate BP_STAMP and reads the response results
+        echo "VALID BP_STAMP: TRUE<br/>";
+        foreach ($_REQUEST as $key => $value){
+            echo $key . ': ' . $value . "<br/>";
+        }
+    } else {
+        echo "ERROR: BP_STAMP VALUES DO NOT MATCH<br/>";
+    }
+} else {
+    echo "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION<br/>"; 
+} 
+?>

--- a/Perl/Get_Data/Transaction_Notification.pl
+++ b/Perl/Get_Data/Transaction_Notification.pl
@@ -17,8 +17,13 @@ my $account_id = "Merchant's Account ID Here";
 my $secret_key = "Merchant's Secret Key Here";
 my $mode = "TEST";
 
+my $tps = BluePay->new(
+    $account_id, 
+    $secret_key, 
+    $mode
+);
+
 my $vars = new CGI;
-my $secret_key = '';
 
 # Check if a Transaction ID was returned from BluePay
 if (defined $vars->param("trans_id")) {
@@ -28,33 +33,22 @@ if (defined $vars->param("trans_id")) {
     my $trans_status = $vars->param("trans_status");
     my $trans_type = $vars->param("trans_type");
     my $amount = $vars->param("amount");
-    my $batch_id = $vars->param("batch_id");
-    my $batch_status = $vars->param("batch_status");
-    my $total_count = $vars->param("total_count");
-    my $total_amount = $vars->param("total_amount");
-    my $batchupload_id = $vars->param("batch_upload_id");
     my $rebill_id = $vars->param("rebill_id");
     my $rebill_amount = $vars->param("reb_amount");
     my $rebill_status = $vars->param("status");
+    my $tps_hash_type = $vars->param("TPS_HASH_TYPE");
+    my $bp_stamp = $vars->param("BP_STAMP");
+    my $bp_stamp_def = $vars->param("BP_STAMP_DEF");
 
     # Calculate expected bp_stamp
-    my $bp_stamp = calc_trans_notify_tps(
-        $secretkey +
-        $trans_id +
-        $trans_status +
-        $trans_type +
-        $amount +
-        $batch_id +
-        $batch_status +
-        $total_count +
-        $total_amount +
-        $batch_upload_id +
-        $rebill_id +
-        $rebill_amount +
-        $rebill_status);
+    my $bp_stamp_string = '';
+    foreach my $field (split(' ', $bp_stamp_def)){
+        $bp_stamp_string .= $vars->param($field);
+    }
+    my $expected_stamp = uc($tps->generate_tps($bp_stamp_string, $tps_hash_type));
 
     # If expected bp_stamp = actual bp_stamp
-    if ($bp_stamp eq $vars->param("BP_STAMP")) {
+    if ($expected_stamp eq $bp_stamp) {
 
     # Get response from BluePay
         print 'Transaction ID: ' + $trans_id;

--- a/Perl/Get_Data/Validate_BP_Stamp.pl
+++ b/Perl/Get_Data/Validate_BP_Stamp.pl
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+##
+# BluePay Perl Sample code.
+#
+# This code sample reads the values from a BP10emu redirect
+# and authenticates the message using the the BP_STAMP
+# provided in the response. Point the REDIRECT_URL of your 
+# BP10emu request to the location of this script on your server.
+##
+
+print "Content-type:text/html\r\n\r\n";
+print "<html><head></head><body>";
+
+use strict;
+use CGI;
+use lib '..';
+use bluepay;
+
+my $account_id = "Merchant's Account ID Here";
+my $secret_key = "Merchant's Secret Key Here";
+my $mode = "TEST";
+
+my $response = new CGI;
+my $response_params = $response->Vars;
+
+if (defined $response_params->{BP_STAMP}){ # Check whether BP_STAMP is provided
+
+	my $bp = BluePay->new(
+	    $account_id, 
+	    $secret_key, 
+	    $mode
+	);
+
+	my $bp_stamp_string = '';
+	foreach my $field (split(' ', $response_params->{BP_STAMP_DEF})){ # Split BP_STAMP_DEF on whitespace
+		$bp_stamp_string .= $response_params->{$field}; # Concatenate values used to calculate expected BP_STAMP
+	}
+
+    my $expected_stamp = uc($bp->generate_tps($bp_stamp_string, $response_params->{TPS_HASH_TYPE})); # Calculate expected BP_STAMP using hash function specified in response
+
+    if ($expected_stamp eq  $response_params->{BP_STAMP}){ # Compare expected BP_STAMP with received BP_STAMP
+    	# Validate BP_STAMP and reads the response results
+        print "VALID BP_STAMP: TRUE<br/>"; 
+    	foreach my $key (keys $response_params){
+    		print $key . ': ' . $response_params->{$key} . "<br/>";
+    	}
+    }
+    else{
+        print "ERROR: BP_STAMP VALUES DO NOT MATCH<br/>";
+    }
+} else{
+    print "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION<br/>";
+}
+
+print "</body></html>";
+}

--- a/Perl/bluepay.pm
+++ b/Perl/bluepay.pm
@@ -25,7 +25,7 @@ sub new {
     $self->{ACCOUNT_ID} = shift;
     $self->{SECRET_KEY} = shift;
     $self->{MODE} = shift;
-    $self->{TPS_HASH_TYPE} = "MD5";
+    $self->{TPS_HASH_TYPE} = "HMAC_SHA512";
 
     # return object
     return $self;

--- a/Perl/bluepay.pm
+++ b/Perl/bluepay.pm
@@ -121,7 +121,7 @@ sub process {
         . "&TAMPER_PROOF_SEAL="
         . uri_escape( $TAMPER_PROOF_SEAL || '' )
         . "&RESPONSEVERSION="
-        . uri_escape("1");
+        . uri_escape("5");
     
     # converts the object's attributes into a query string for the api request
     while ( my ( $key, $value ) = each(%$self) ) {

--- a/Python/BluePay.py
+++ b/Python/BluePay.py
@@ -677,7 +677,7 @@ class BluePay:
         fields = {
             'MODE': self.mode,
             'RRNO': self.rrno,
-            'RESPONSEVERSION': '1' # Response version to be returned   
+            'RESPONSEVERSION': '5' # Response version to be returned   
         }
         if self.api == 'bpdailyreport2':
             self.url = 'https://secure.bluepay.com/interfaces/bpdailyreport2'

--- a/Python/BluePay.py
+++ b/Python/BluePay.py
@@ -97,7 +97,7 @@ class BluePay:
     # Processing fields
     url = ''
     api = ''
-    tps_hash_type = 'MD5'
+    tps_hash_type = 'HMAC_SHA512'
 
     # Level 2 Processing field
     level2_info = {}

--- a/Python/BluePay.py
+++ b/Python/BluePay.py
@@ -404,19 +404,19 @@ class BluePay:
     ### API REQUEST ###
 
     # Functions for calculating the TAMPER_PROOF_SEAL
-    def create_tps_hash(self, string):
+    def create_tps_hash(self, string, hash_type):
         tps_hash = ""
-        if self.tps_hash_type == "HMAC_SHA256":
+        if hash_type == "HMAC_SHA256":
             tps_hash = hmac.new(self.secret_key, string, hashlib.sha256).hexdigest()
-        elif self.tps_hash_type == "SHA512":
+        elif hash_type == "SHA512":
             m = hashlib.sha512()
             m.update(self.secret_key + string)
             tps_hash = m.hexdigest()
-        elif self.tps_hash_type == "SHA256":
+        elif hash_type == "SHA256":
             m = hashlib.sha256()
             m.update(self.secret_key + string)
             tps_hash = m.hexdigest()
-        elif self.tps_hash_type == "MD5":
+        elif hash_type == "MD5":
             m = hashlib.md5()
             m.update(self.secret_key + string)
             tps_hash = m.hexdigest()
@@ -430,23 +430,17 @@ class BluePay:
         tps_string = (self.account_id + self.trans_type + self.amount + self.do_rebill + 
                         self.reb_first_date + self.reb_expr + self.reb_cycles + self.reb_amount + 
                         self.rrno + self.mode)
-        tps = self.create_tps_hash(tps_string)
+        tps = self.create_tps_hash(tps_string, self.tps_hash_type)
         return tps
 
     def calc_rebill_TPS(self):
         tps_string = (self.account_id + self.trans_type + self.rebill_id)
-        tps = self.create_tps_hash(tps_string)
+        tps = self.create_tps_hash(tps_string, self.tps_hash_type)
         return tps 
         
     def calc_report_TPS(self):
         tps_string = (self.account_id + self.report_start_date + self.report_end_date)
-        tps = self.create_tps_hash(tps_string)
-        return tps
-        
-    def calc_trans_notify_TPS(self):
-        tps_string = (trans_id, trans_status, trans_type, amount, batch_id, batch_status,
-                      total_count, total_amount, batch_upload_id, rebill_id, rebill_amount, rebill_status)
-        tps = self.create_tps_hash(tps_string)
+        tps = self.create_tps_hash(tps_string, self.tps_hash_type)
         return tps
 
     # Required arguments for generate_url:
@@ -533,19 +527,28 @@ class BluePay:
         else:
             self.receipt_form_id = "mobileresult01"
         if 'receipt_temp_remote_url' in params:
-            self.remote_url = params['receipt_temp_remote_url'] 
+            self.remote_url = params['receipt_temp_remote_url']
+        self.shpf_tps_hash_type = 'HMAC_SHA512'
+        self.receipt_tps_hash_type = self.shpf_tps_hash_type
+        self.tps_hash_type = self.set_hash_type(params.get('tps_hash_type', ''))
         self.card_types = self.set_card_types()
-        self.receipt_tps_def = 'SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF'
+        self.receipt_tps_def = 'SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE'
         self.receipt_tps_string = self.set_receipt_tps_string()
-        self.receipt_tamper_proof_seal = self.calc_url_tps(self.receipt_tps_string)
+        self.receipt_tamper_proof_seal = self.create_tps_hash(self.receipt_tps_string, self.receipt_tps_hash_type)
         self.receipt_url = self.set_receipt_url()
-        self.bp10emu_tps_def = self.add_def_protected_status('MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF')
+        self.bp10emu_tps_def = self.add_def_protected_status('MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF TPS_HASH_TYPE')
         self.bp10emu_tps_string = self.set_bp10emu_tps_string()
-        self.bp10emu_tamper_proof_seal = self.calc_url_tps(self.bp10emu_tps_string)
-        self.shpf_tps_def = self.add_def_protected_status('SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF SHPF_TPS_DEF')
+        self.bp10emu_tamper_proof_seal = self.create_tps_hash(self.bp10emu_tps_string, self.tps_hash_type)
+        self.shpf_tps_def = self.add_def_protected_status('SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF TPS_HASH_TYPE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE')
         self.shpf_tps_string = self.set_shpf_tps_string()
-        self.shpf_tamper_proof_seal = self.calc_url_tps(self.shpf_tps_string)
+        self.shpf_tamper_proof_seal = self.create_tps_hash(self.shpf_tps_string, self.shpf_tps_hash_type)
         return self.calc_url_response()
+
+    # Validates hash type or uses default
+    def set_hash_type(self, chosen_hash):
+        default_hash = 'HMAC_SHA512'
+        result = chosen_hash.upper() if chosen_hash.upper() in ['MD5', 'SHA256', 'SHA512', 'HMAC_SHA256'] else default_hash
+        return result
 
     # Sets the types of credit card images to use on the Simple Hosted Payment Form. Must be used with generate_url.
     def set_card_types(self):
@@ -558,38 +561,39 @@ class BluePay:
 
     # Sets the receipt Tamperproof Seal string. Must be used with generate_url.
     def set_receipt_tps_string(self):
-        return ''.join(self.secret_key +
-            self.account_id +
+        return ''.join(self.account_id +
             self.receipt_form_id +
             self.return_url +
             self.dba +
             self.accept_amex +
             self.accept_discover +
-            self.receipt_tps_def)
+            self.receipt_tps_def + 
+            self.receipt_tps_hash_type)
 
     # Sets the bp10emu string that will be used to create a Tamperproof Seal. Must be used with generate_url.
     def set_bp10emu_tps_string(self):
-        bp10emu = ''.join(self.secret_key +
-            self.account_id + 
+        bp10emu = ''.join(self.account_id + 
             self.receipt_url + 
             self.receipt_url +
             self.receipt_url +
             self.mode +
             self.trans_type +
-            self.bp10emu_tps_def)
+            self.bp10emu_tps_def + 
+            self.tps_hash_type)
         return self.add_string_protected_status(bp10emu)
 
     # Sets the Simple Hosted Payment Form string that will be used to create a Tamperproof Seal. Must be used with generate_url.
     def set_shpf_tps_string(self):
-        shpf = ''.join(self.secret_key +
-            self.shpf_form_id +
+        shpf = ''.join(self.shpf_form_id +
             self.account_id + 
             self.dba + 
             self.bp10emu_tamper_proof_seal +
             self.accept_amex +
             self.accept_discover +
             self.bp10emu_tps_def +
-            self.shpf_tps_def)
+            self.tps_hash_type +
+            self.shpf_tps_def + 
+            self.shpf_tps_hash_type)
         return self.add_string_protected_status(shpf)
 
     # Sets the receipt url or uses the remote url provided. Must be used with generate_url.
@@ -601,6 +605,7 @@ class BluePay:
             'SHPF_FORM_ID=' + self.receipt_form_id + 
             '&SHPF_ACCOUNT_ID=' + self.account_id + 
             '&SHPF_TPS_DEF=' + self.url_encode(self.receipt_tps_def) + 
+            '&SHPF_TPS_HASH_TYPE=' + self.url_encode(self.receipt_tps_hash_type) +
             '&SHPF_TPS=' + self.url_encode(self.receipt_tamper_proof_seal) + 
             '&RETURN_URL=' + self.url_encode(self.return_url) + 
             '&DBA=' + self.url_encode(self.dba) + 
@@ -640,18 +645,13 @@ class BluePay:
             encoded_string += char
         return encoded_string
     
-    # Generates a Tamperproof Seal for a url. Must be used with generate_url.
-    def calc_url_tps(self, tps_type):
-        m = hashlib.md5()
-        m.update(tps_type)
-        return m.hexdigest()
-
     # Generates the final url for the Simple Hosted Payment Form. Must be used with generate_url.
     def calc_url_response(self):
         return ''.join('https://secure.bluepay.com/interfaces/shpf?' +
             'SHPF_FORM_ID='       + self.url_encode(self.shpf_form_id) +
             '&SHPF_ACCOUNT_ID='   + self.url_encode(self.account_id) +
             '&SHPF_TPS_DEF='      + self.url_encode(self.shpf_tps_def) +
+            '&SHPF_TPS_HASH_TYPE='+ self.url_encode(self.shpf_tps_hash_type) +
             '&SHPF_TPS='          + self.url_encode(self.shpf_tamper_proof_seal) +
             '&MODE='              + self.url_encode(self.mode) +
             '&TRANSACTION_TYPE='  + self.url_encode(self.trans_type) +
@@ -668,14 +668,16 @@ class BluePay:
             '&AMEX_IMAGE='        + self.url_encode(self.accept_amex) +
             '&DISCOVER_IMAGE='    + self.url_encode(self.accept_discover) +
             '&REDIRECT_URL='      + self.url_encode(self.receipt_url) +
-            '&TPS_DEF='           + self.url_encode(self.bp10emu_tps_def)+
+            '&TPS_DEF='           + self.url_encode(self.bp10emu_tps_def) +
+            '&TPS_HASH_TYPE='     + self.url_encode(self.tps_hash_type) +
             '&CARD_TYPES='        + self.url_encode(self.card_types))
 
     ### PROCESSES THE API REQUEST ####
     def process(self, card=None, customer=None, order=None):
         fields = {
             'MODE': self.mode,
-            'RRNO': self.rrno
+            'RRNO': self.rrno,
+            'RESPONSEVERSION': '1' # Response version to be returned   
         }
         if self.api == 'bpdailyreport2':
             self.url = 'https://secure.bluepay.com/interfaces/bpdailyreport2'
@@ -896,8 +898,12 @@ class BluePay:
         self.trans_type_response = self.response['trans_type'][0] if 'trans_type' in self.response else ''
         # Amount associated with the transaction
         self.amount_response = self.response['amount'][0] if 'amount' in self.response else ''
-
-    
+        # Returns the BP_STAMP used to authenticate response
+        self.bp_stamp_response = self.response['BP_STAMP'][0] if 'BP_STAMP' in self.response else ''
+        # Returns the fields used to calculate the BP_STAMP
+        self.bp_stamp_def_response = self.response['BP_STAMP_DEF'][0] if 'BP_STAMP_DEF' in self.response else ''
+        # Returns hash function used for transaction
+        self.tps_hash_type_response = self.response['TPS_HASH_TYPE'][0] if 'TPS_HASH_TYPE' in self.response else ''
 
 
  

--- a/Python/Get_Data/Transaction_Notification.py
+++ b/Python/Get_Data/Transaction_Notification.py
@@ -14,39 +14,38 @@ import cgi
 
 vars = cgi.FieldStorage()
 
+account_id = "Merchant's Account ID Here"
 secret_key = "Merchant's Secret Key Here"
+mode = "TEST"  
+
+tps = BluePay(
+    account_id = account_id, 
+    secret_key = secret_key, 
+    mode = mode 
+)
+
 try:
     # Assign values
     trans_id = vars["trans_id"]
     trans_status = vars["trans_status"]
     trans_type = vars["trans_type"]
     amount = vars["amount"]
-    batch_id = vars["batch_id"]
-    batch_status = vars["batch_status"]
-    total_count = vars["total_count"]
-    total_amount = vars["total_amount"]
-    batch_upload_id = vars["batch_upload_id"]
     rebill_id = vars["rebill_id"]
     rebill_amount = vars["reb_amount"]
     rebill_status = vars["status"]
+    tps_hash_type = vars["TPS_HASH_TYPE"]
+    bp_stamp = vars["BP_STAMP"]
+    bp_stamp_def = vars["BP_STAMP_DEF"]
 
     # Calculate expected bp_stamp
-    bp_stamp = BluePay.calc_trans_notify_TPS(secret_key,
-        trans_id,
-        trans_status,
-        trans_type,
-        amount,
-        batch_id,
-        batch_status,
-        total_count,
-        total_amount,
-        batch_upload_id,
-        rebill_id,
-        rebill_amount,
-        rebill_status)
+    bp_stamp_string = ''
+    for field in bp_stamp_def.value.split(' '): 
+        bp_stamp_string += vars[field].value 
+
+    expected_stamp = tps.create_tps_hash(bp_stamp_string, tps_hash_type.value).upper()
 
     # check if expected bp_stamp = actual bp_stamp
-    if bp_stamp == vars["bp_stamp"]:
+    if exepcted_stamp == bp_stamp:
 
         # Get response from BluePay
         print('Transaction ID: ' + trans_id)

--- a/Python/Get_Data/Validate_BP_Stamp.py
+++ b/Python/Get_Data/Validate_BP_Stamp.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+
+##
+ # BluePay Python Sample code.
+ #
+ # This code sample reads the values from a BP10emu redirect
+ # and authenticates the message using the the BP_STAMP
+ # provided in the response. Point the REDIRECT_URL of your 
+ # BP10emu request to the location of this script on your server.
+##
+
+from __future__ import print_function
+import os.path, sys
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+from BluePay import BluePay
+import cgi
+
+print("Content-type:text/html\r\n\r\n")
+print("<html><head></head><body>")
+
+response = cgi.FieldStorage()
+
+account_id = "Merchant's Account ID Here"
+secret_key = "Merchant's Secret Key Here"
+mode = "TEST"  
+
+
+if "BP_STAMP" in response: # Check whether BP_STAMP is provided
+
+    bp = BluePay(
+        account_id = account_id, 
+        secret_key = secret_key, 
+        mode = mode 
+    )
+
+    bp_stamp_string = ''
+    for field in response["BP_STAMP_DEF"].value.split(' '): # Split BP_STAMP_DEF on whitespace
+        bp_stamp_string += response[field].value # Concatenate values used to calculate expected BP_STAMP
+
+    expected_stamp = bp.create_tps_hash(bp_stamp_string, response["TPS_HASH_TYPE"].value).upper() # Calculate expected BP_STAMP using hash function specified in response
+    if expected_stamp == response['BP_STAMP'].value: # Compare expected BP_STAMP with received BP_STAMP
+        # Validate BP_STAMP and reads the response results
+        print("VALID BP_STAMP: TRUE<br/>")
+        for key in response.keys():
+            print(key + ': ' + response[key].value + "<br/>")
+    else:
+        print("ERROR: BP_STAMP VALUES DO NOT MATCH<br/>")
+    
+else:
+    print("ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION<br/>")
+
+print("</body></html>")

--- a/Ruby/lib/api_request.rb
+++ b/Ruby/lib/api_request.rb
@@ -68,7 +68,7 @@ class BluePay
     ua.use_ssl = true
     
     # Set default hash function to HMAC SHA-512
-    @PARAM_HASH['TPS_HASH_TYPE'] = 'HMAC_SHA-512'
+    @PARAM_HASH['TPS_HASH_TYPE'] = 'HMAC_SHA512'
 
     # Checks presence of CA certificate
     if File.directory?(RootCA)

--- a/Ruby/lib/api_request.rb
+++ b/Ruby/lib/api_request.rb
@@ -87,7 +87,7 @@ class BluePay
     end
 
     # Response version to be returned
-    @PARAM_HASH["RESPONSEVERSION"] = '1'
+    @PARAM_HASH["RESPONSEVERSION"] = '5'
 
     # Generate the query string and headers.  Chooses which API to make request to.
     case @api

--- a/Ruby/lib/api_request.rb
+++ b/Ruby/lib/api_request.rb
@@ -9,8 +9,8 @@ class BluePay
   end
 
   # Generates TPS hash based on given hash type
-  def create_tps_hash(data)
-    case @PARAM_HASH['TPS_HASH_TYPE']   
+  def create_tps_hash(data, hash_type)
+    case hash_type   
     when 'HMAC_SHA256'
       OpenSSL::HMAC.hexdigest('sha256', @SECRET_KEY, data)
     when 'SHA512'
@@ -36,7 +36,8 @@ class BluePay
         (@PARAM_HASH["REB_CYCLES"] || '') + 
         (@PARAM_HASH["REB_AMOUNT"] || '') + 
         (@PARAM_HASH["RRNO"] || '') + 
-        @PARAM_HASH["MODE"]
+        @PARAM_HASH["MODE"], 
+        @PARAM_HASH['TPS_HASH_TYPE']
       )
   end
 
@@ -45,7 +46,8 @@ class BluePay
     @PARAM_HASH["TAMPER_PROOF_SEAL"] = create_tps_hash(
       @ACCOUNT_ID +
       @PARAM_HASH["TRANS_TYPE"] + 
-      @PARAM_HASH["REBILL_ID"]
+      @PARAM_HASH["REBILL_ID"], 
+      @PARAM_HASH['TPS_HASH_TYPE']
     )
   end
 
@@ -54,26 +56,9 @@ class BluePay
     @PARAM_HASH["TAMPER_PROOF_SEAL"] = create_tps_hash(
       @ACCOUNT_ID + 
       @PARAM_HASH["REPORT_START_DATE"] + 
-      @PARAM_HASH["REPORT_END_DATE"]
+      @PARAM_HASH["REPORT_END_DATE"],
+      @PARAM_HASH['TPS_HASH_TYPE']
       )
-  end
-
-  # Calculates TAMPER_PROOF_SEAL to be used with Trans Notify API 
-  def self.calc_trans_notify_tps(trans_id, trans_status, trans_type, amount, batch_id, batch_status, total_count, total_amount, batch_upload_id, rebill_id, rebill_amount, rebill_status)
-    create_tps_hash(
-      trans_id + 
-      trans_status + 
-      transtype + 
-      amount + 
-      batch_id + 
-      batch_status + 
-      total_count + 
-      total_amount + 
-      batch_upload_id + 
-      rebill_id + 
-      rebill_amount + 
-      rebill_status
-    )
   end
 
  # sends HTTPS POST to BluePay gateway for processing
@@ -101,6 +86,9 @@ class BluePay
       rescue Exception
     end
 
+    # Response version to be returned
+    @PARAM_HASH["RESPONSEVERSION"] = '1'
+
     # Generate the query string and headers.  Chooses which API to make request to.
     case @api
     when "bpdailyreport2"
@@ -125,8 +113,6 @@ class BluePay
       'User-Agent' => 'Bluepay Ruby Client',
       'Content-Type' => 'application/x-www-form-urlencoded'
     }
-    # Response version to be returned
-    @PARAM_HASH["VERSION"] = '3'
     # Post parameters to BluePay gateway
     headers, body = ua.post(path, query, queryheaders)
     # Split the response into the response hash.

--- a/Ruby/lib/api_request.rb
+++ b/Ruby/lib/api_request.rb
@@ -68,7 +68,7 @@ class BluePay
     ua.use_ssl = true
     
     # Set default hash function to HMAC SHA-512
-    @PARAM_HASH['TPS_HASH_TYPE'] = 'MD5'
+    @PARAM_HASH['TPS_HASH_TYPE'] = 'HMAC_SHA-512'
 
     # Checks presence of CA certificate
     if File.directory?(RootCA)

--- a/Ruby/lib/api_response.rb
+++ b/Ruby/lib/api_response.rb
@@ -2,7 +2,7 @@ class BluePay
   def get_response
     @RESPONSE_HASH
   end
-
+  
   # Returns true if response status is approved and not a duplicate, else returns false
   def successful_transaction?
     self.get_status == "APPROVED" && self.get_message != "DUPLICATE"
@@ -22,6 +22,21 @@ class BluePay
     else
       m
     end
+  end
+
+  # Returns the BP_STAMP used to authenticate response
+  def get_bp_stamp
+    @RESPONSE_HASH['BP_STAMP']
+  end
+
+  # Returns the fields used to calculate the BP_STAMP
+  def get_bp_stamp_def
+    @RESPONSE_HASH['BP_STAMP_DEF']
+  end
+  
+  # Returns hash function used for transaction
+  def get_hash_type
+    @RESPONSE_HASH['TPS_HASH_TYPE']
   end
 
   # Returns the single-character AVS response from the 

--- a/Ruby/samples/Get_Data/Transaction_Notification.rb
+++ b/Ruby/samples/Get_Data/Transaction_Notification.rb
@@ -10,9 +10,13 @@
 require_relative "../../lib/bluepay.rb"
 require "cgi"
 
-vars = CGI.new
+ACCOUNT_ID = "Merchant's Account ID Here"
+SECRET_KEY = "Merchant's Secret Key Here"
+MODE = "TEST" 
 
-secret_key = ""
+tps = BluePay.new(account_id: ACCOUNT_ID, secret_key: SECRET_KEY, mode: MODE)
+
+vars = CGI.new
 
 # Assign values
 trans_id = vars["trans_id"]
@@ -20,33 +24,22 @@ trans_status = vars["trans_status"]
 trans_type = vars["trans_type"]
 amount = vars["amount"]
 batch_id = vars["batch_id"]
-batch_status = vars["batch_status"]
-total_count = vars["total_count"]
-total_amount = vars["total_amount"]
-batch_upload_id = vars["batch_upload_id"]
 rebill_id = vars["rebill_id"]
 rebill_amount = vars["reb_amount"]
 rebill_status = vars["status"]
+tps_hash_type = vars["TPS_HASH_TYPE"]
+bp_stamp = vars["BP_STAMP"]
+bp_stamp_def = vars["BP_STAMP_DEF"]
 
 # Calculate expected bp_stamp
-bp_stamp = BluePay.calc_trans_notify_tps(
-  secret_key,
-  trans_id,
-  trans_status,
-  trans_type,
-  amount,
-  batch_id,
-  batch_status,
-  total_count,
-  total_amount,
-  batch_upload_id,
-  rebill_id,
-  rebill_amount,
-  rebill_status
-)
+bp_stamp_string = ''
+bp_stamp_def.split(' ').each do |field| 
+  bp_stamp_string += vars[field]
+end
+expected_stamp = tps.create_tps_hash(bp_stamp_string, tps_hash_type).upcase
 
 # check if expected bp_stamp = actual bp_stamp
-if bp_stamp == vars["bp_stamp"]
+if expected_stamp == vars["BP_STAMP"]
 
   # Reads the response from BluePay
   puts 'Transaction ID: ' + trans_id

--- a/Ruby/samples/Get_Data/Validate_BP_Stamp.rb
+++ b/Ruby/samples/Get_Data/Validate_BP_Stamp.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/ruby
+
+##
+# BluePay Ruby Sample code.
+#
+# This code sample reads the values from a BP10emu redirect
+# and authenticates the message using the the BP_STAMP
+# provided in the response. Point the REDIRECT_URL of your 
+# BP10emu request to the location of this script on your server.
+##
+
+print "Content-type:text/html\r\n\r\n"
+print "<html><head></head><body>"
+
+require_relative "bluepay.rb"
+require "cgi"
+
+ACCOUNT_ID = "Merchant's Account ID Here"
+SECRET_KEY = "Merchant's Secret Key Here"
+MODE = "TEST" 
+
+response = CGI.new
+
+if response["BP_STAMP"] # Check whether BP_STAMP is provided
+
+  bp = BluePay.new(account_id: ACCOUNT_ID, secret_key: SECRET_KEY, mode: MODE)
+
+  bp_stamp_string = ''
+  response["BP_STAMP_DEF"].split(' ').each do |field| # Split BP_STAMP_DEF on whitespace
+    bp_stamp_string += response[field] # Concatenate values used to calculate expected BP_STAMP
+  end
+  expected_stamp = bp.create_tps_hash(bp_stamp_string, response["TPS_HASH_TYPE"]).upcase # Calculate expected BP_STAMP using hash function specified in response
+
+  if expected_stamp == response["BP_STAMP"] # Compare expected BP_STAMP with received BP_STAMP
+    # Validate BP_STAMP and reads the response results
+    print "VALID BP_STAMP: TRUE<br/>"
+    response.params.each{|k,v| print "#{k}: #{v[0]}<br/>"}
+  else
+    print "ERROR: BP_STAMP VALUES DO NOT MATCH<br/>"
+  end
+
+else
+  print "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION<br/>"
+end
+
+print "</body></html>"

--- a/VB/vbnet/Application.vb
+++ b/VB/vbnet/Application.vb
@@ -1,6 +1,4 @@
-﻿
-
-Public Class Application
+﻿Public Class Application
 	Public Shared Sub Main()
     
         ''''''''''''''''''''''''''''''''''''''''''''''''
@@ -28,6 +26,8 @@ Public Class Application
 		' GetData.SingleTransactionQuery.run()
 		' GetData.RetrieveTransactionData.run()
 		' GetData.RetrieveSettlementData.run()
+        ' GetData.TransactionNotification.run()
+		' GetData.ValidateBPStamp.run()
 
 	End Sub
 End Class

--- a/VB/vbnet/BluePay.vb
+++ b/VB/vbnet/BluePay.vb
@@ -119,7 +119,7 @@ Namespace BPVB
         Private excludeErrors As String = ""
 
         Private TPS As String = ""
-        Private tpsHashType As String = "MD5"
+        Private tpsHashType As String = "HMAC_SHA512"
         Private api As String = ""
         Public response As String = ""
 

--- a/VB/vbnet/BluePay.vb
+++ b/VB/vbnet/BluePay.vb
@@ -998,7 +998,7 @@ Namespace BPVB
 
         Public Function process() As String
             Dim postData As String = "MODE=" + HttpUtility.UrlEncode(Me.mode)
-            postData = postData + "&RESPONSEVERSION=1"
+            postData = postData + "&RESPONSEVERSION=5"
             'If (Me.transType <> "SET" And Me.transType <> "GET") Then
             If (Me.API = "bp10emu") Then
                 calcTPS()

--- a/VB/vbnet/BluePay.vb
+++ b/VB/vbnet/BluePay.vb
@@ -95,6 +95,8 @@ Namespace BPVB
         Private shpfFormID As String = ""
         Private receiptFormID As String = ""
         Private remoteURL As String = ""
+        Private shpfTpsHashType As String = ""
+        Private receiptTpsHashType As String = ""
         Private cardTypes As String = ""
         Private receiptTpsDef As String = ""
         Private receiptTpsString As String = ""
@@ -649,28 +651,28 @@ Namespace BPVB
         ''' Generates the TAMPER_PROOF_SEAL to used to validate each transaction
         ''' </summary>
         '''
-        Public Function generateTPS(ByVal message As String) As String
+        Public Function generateTPS(ByVal message As String, ByVal hashType As String) As String
             Dim result As String
             Dim encode As ASCIIEncoding = New ASCIIEncoding
-            If Me.tpsHashType = "HMAC_SHA256" Then
+            If hashType = "HMAC_SHA256" Then
                 Dim secretKeyBytes() As Byte = encode.GetBytes(Me.secretKey)
                 Dim messageBytes() As Byte = encode.GetBytes(message)
                 Dim hmac As HMACSHA256 = New HMACSHA256(secretKeyBytes)
                 Dim hashBytes() As Byte = hmac.ComputeHash(messageBytes)
                 result = ByteArrayToString(hashBytes)
-            Elseif Me.tpsHashType = "SHA512" Then
+            Elseif hashType = "SHA512" Then
                 Dim sha512 As SHA512 = New SHA512Managed()
                 Dim hash() As Byte
                 Dim buffer() As Byte = encode.GetBytes(Me.secretKey + message)
                 hash = sha512.ComputeHash(buffer)
                 result = ByteArrayToString(hash)
-            Elseif Me.tpsHashType = "SHA256" Then
+            Elseif hashType = "SHA256" Then
                 Dim sha256 As SHA256 = New SHA256Managed()
                 Dim hash() As Byte
                 Dim buffer() As Byte = encode.GetBytes(Me.secretKey + message)
                 hash = sha256.ComputeHash(buffer)
                 result = ByteArrayToString(hash)
-            Elseif Me.tpsHashType = "MD5" Then
+            Elseif hashType = "MD5" Then
                 Dim md5 As MD5 = New MD5CryptoServiceProvider
                 Dim hash() As Byte
                 Dim buffer() As Byte = encode.GetBytes(Me.secretKey + message)
@@ -701,7 +703,7 @@ Namespace BPVB
                         + Me.rebillAmount _
                         + Me.masterID _
                         + Me.mode
-            Me.TPS = generateTPS(tps)
+            Me.TPS = generateTPS(tps, Me.tpsHashType)
         End Sub
 
         ''' <summary>
@@ -712,7 +714,7 @@ Namespace BPVB
             Dim tps As String = Me.accountID _
                         + Me.reportStartDate _
                         + Me.reportEndDate
-            Me.TPS = generateTPS(tps)
+            Me.TPS = generateTPS(tps, Me.tpsHashType)
         End Sub
 
 
@@ -724,16 +726,8 @@ Namespace BPVB
             Dim tps As String = Me.accountID _
                         + Me.transType _
                         + Me.rebillID
-            Me.TPS = generateTPS(tps)
+            Me.TPS = generateTPS(tps, Me.tpsHashType)
         End Sub
-
-        ''' <summary>
-        ''' Calculates BP_STAMP for trans notify post API
-        ''' </summary>
-        '''
-        Public Shared Function calcTransNotifyTPS(ByVal bp_stamp As String)
-            Return generateTPS(bp_stamp)
-        End Function
 
         'This is used to convert a byte array to a hex string
         Private Shared Function ByteArrayToString(ByVal arrInput() As Byte) As String
@@ -808,7 +802,7 @@ Namespace BPVB
         ''' <param name="paymentTemplate"></param>
         ''' <param name="receiptTemplate"></param>
         ''' <param name="receiptTempRemoteURL"></param>
-        Public Function generateURL(Optional ByVal merchantName As String = "", Optional ByVal returnURL As String = "", Optional ByVal transactionType As String = "",  Optional ByVal acceptDiscover As String = "", Optional ByVal acceptAmex As String = "", Optional ByVal amount As String = "", Optional ByVal protectAmount As String = "No", Optional ByVal rebilling As String = "No", Optional ByVal rebProtect As String = "Yes", Optional ByVal rebAmount As String = "", Optional ByVal rebCycles As String = "", Optional ByVal rebStartDate As String = "", Optional ByVal rebFrequency As String = "", Optional ByVal customID1 As String = "", Optional ByVal protectCustomID1 = "No", Optional ByVal customID2 As String = "", Optional ByVal protectCustomID2 As String = "No", Optional ByVal paymentTemplate As String = "mobileform01", Optional ByVal receiptTemplate As String = "mobileresult01", Optional ByVal receiptTempRemoteURL As String = "") As String
+        Public Function generateURL(Optional ByVal merchantName As String = "", Optional ByVal returnURL As String = "", Optional ByVal transactionType As String = "",  Optional ByVal acceptDiscover As String = "", Optional ByVal acceptAmex As String = "", Optional ByVal amount As String = "", Optional ByVal protectAmount As String = "No", Optional ByVal rebilling As String = "No", Optional ByVal rebProtect As String = "Yes", Optional ByVal rebAmount As String = "", Optional ByVal rebCycles As String = "", Optional ByVal rebStartDate As String = "", Optional ByVal rebFrequency As String = "", Optional ByVal customID1 As String = "", Optional ByVal protectCustomID1 = "No", Optional ByVal customID2 As String = "", Optional ByVal protectCustomID2 As String = "No", Optional ByVal paymentTemplate As String = "mobileform01", Optional ByVal receiptTemplate As String = "mobileresult01", Optional ByVal receiptTempRemoteURL As String = "", Optional ByVal tpsHashType As String = "") As String
             Me.dba = merchantName
             Me.returnURL = returnURL
             Me.transType = transactionType
@@ -829,20 +823,43 @@ Namespace BPVB
             Me.shpfFormID = paymentTemplate
             Me.receiptFormID = receiptTemplate
             Me.remoteURL = receiptTempRemoteURL
+            Me.shpfTpsHashType = "HMAC_SHA512"
+            Me.receiptTpsHashType = Me.shpfTpsHashType
+            Me.tpsHashType = setHashType(tpsHashType)
             Me.cardTypes = setCardTypes()
-            Me.receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF"
+            Me.receiptTpsDef = "SHPF_ACCOUNT_ID SHPF_FORM_ID RETURN_URL DBA AMEX_IMAGE DISCOVER_IMAGE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE"
             Me.receiptTpsString = setReceiptTpsString()
-            Me.receiptTamperProofSeal = calcURLTps(Me.receiptTpsString)
+            Me.receiptTamperProofSeal = generateTPS(Me.receiptTpsString, Me.receiptTpsHashType)
             Me.receiptURL = setReceiptURL()
-            Me.bp10emuTpsDef = addDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF")
+            Me.bp10emuTpsDef = addDefProtectedStatus("MERCHANT APPROVED_URL DECLINED_URL MISSING_URL MODE TRANSACTION_TYPE TPS_DEF TPS_HASH_TYPE")
             Me.bp10emuTpsString = setBp10emuTpsString()
-            Me.bp10emuTamperProofSeal = calcURLTps(Me.bp10emuTpsString)
-            Me.shpfTpsDef = addDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF SHPF_TPS_DEF")
+            Me.bp10emuTamperProofSeal = generateTPS(Me.bp10emuTpsString, Me.tpsHashType)
+            Me.shpfTpsDef = addDefProtectedStatus("SHPF_FORM_ID SHPF_ACCOUNT_ID DBA TAMPER_PROOF_SEAL AMEX_IMAGE DISCOVER_IMAGE TPS_DEF TPS_HASH_TYPE SHPF_TPS_DEF SHPF_TPS_HASH_TYPE")
             Me.shpfTpsString = setShpfTpsString()
-            Me.shpfTamperProofSeal = calcURLTps(Me.shpfTpsString)
+            Me.shpfTamperProofSeal = generateTPS(Me.shpfTpsString, Me.shpfTpsHashType)
             Return calcURLResponse()
         End Function
 
+        ''' <summary>
+        ''' Validates chosen hash type or returns default hash type
+        ''' </summary>
+        Public Function setHashType(ByVal chosenHash As String) As String
+            Dim defaultHash As String = "HMAC_SHA512"
+            chosenHash = chosenHash.ToUpper()
+            Dim result As String = ""
+            Dim hashes As ArrayList = New ArrayList(4)
+            hashes.Add("MD5")
+            hashes.Add("SHA256")
+            hashes.Add("SHA512")
+            hashes.Add("HMAC_SHA256")
+            If hashes.Contains(chosenHash) Then
+                result = chosenHash
+            Else
+                result = defaultHash
+            End If 
+            Return result
+        End Function
+        
         ''' <summary>
         ''' Sets the types of credit card images to use on the Simple Hosted Payment Form, used in public string GenerateURL()
         ''' </summary>
@@ -857,14 +874,14 @@ Namespace BPVB
         ''' Sets the receipt Tamperproof Seal string, used in public string GenerateURL()
         ''' </summary>
         Public Function setReceiptTpsString() As String
-            Return Me.secretKey + Me.accountID + Me.receiptFormID + Me.returnURL + Me.dba + Me.amexImage + Me.discoverImage + Me.receiptTpsDef
+            Return Me.accountID + Me.receiptFormID + Me.returnURL + Me.dba + Me.amexImage + Me.discoverImage + Me.receiptTpsDef + Me.receiptTpsHashType
         End Function
 
         ''' <summary>
         ''' Sets the bp10emu string that will be used to create a Tamperproof Seal, used in public string GenerateURL()
         ''' </summary>
         Public Function setBp10emuTpsString() As String
-            Dim bp10emu As String = Me.secretKey + Me.accountID + Me.receiptURL + Me.receiptURL + Me.receiptURL + Me.mode + Me.transType + Me.bp10emuTpsDef
+            Dim bp10emu As String = Me.accountID + Me.receiptURL + Me.receiptURL + Me.receiptURL + Me.mode + Me.transType + Me.bp10emuTpsDef + Me.tpsHashType
             Return addStringProtectedStatus(bp10emu)
         End Function
 
@@ -872,7 +889,7 @@ Namespace BPVB
         ''' Sets the Simple Hosted Payment Form string that will be used to create a Tamperproof Seal, used in public string GenerateURL()
         ''' </summary>
         Public Function setShpfTpsString() As String
-            Dim shpf As String = Me.secretKey + Me.shpfFormID + Me.accountID + Me.dba + Me.bp10emuTamperProofSeal + Me.amexImage + Me.discoverImage + Me.bp10emuTpsDef + Me.shpfTpsDef
+            Dim shpf As String = Me.shpfFormID + Me.accountID + Me.dba + Me.bp10emuTamperProofSeal + Me.amexImage + Me.discoverImage + Me.bp10emuTpsDef + Me.tpsHashType + Me.shpfTpsDef + Me.shpfTpsHashType
             Return addStringProtectedStatus(shpf)
         End Function
 
@@ -885,13 +902,14 @@ Namespace BPVB
                 output = Me.remoteURL
             Else 
                 output =  "https://secure.bluepay.com/interfaces/shpf?SHPF_FORM_ID=" + Me.receiptFormID + _
-                "&SHPF_ACCOUNT_ID=" + Me.accountID +  _
-                "&SHPF_TPS_DEF="    + encodeURL(Me.receiptTpsDef) +  _
-                "&SHPF_TPS="        + encodeURL(Me.receiptTamperProofSeal) +  _
-                "&RETURN_URL="      + encodeURL(Me.returnURL) + _
-                "&DBA="             + encodeURL(Me.dba) +  _
-                "&AMEX_IMAGE="      + encodeURL(Me.amexImage) +  _
-                "&DISCOVER_IMAGE="  + encodeURL(Me.discoverImage)
+                "&SHPF_ACCOUNT_ID="     + Me.accountID +  _
+                "&SHPF_TPS_DEF="        + encodeURL(Me.receiptTpsDef) +  _
+                "&SHPF_TPS_HASH_TYPE="  + encodeURL(Me.receiptTpsHashType) +  _
+                "&SHPF_TPS="            + encodeURL(Me.receiptTamperProofSeal) +  _
+                "&RETURN_URL="          + encodeURL(Me.returnURL) + _
+                "&DBA="                 + encodeURL(Me.dba) +  _
+                "&AMEX_IMAGE="          + encodeURL(Me.amexImage) +  _
+                "&DISCOVER_IMAGE="      + encodeURL(Me.discoverImage)
             End If
             Return output
         End Function
@@ -956,6 +974,7 @@ Namespace BPVB
             "SHPF_FORM_ID="         + encodeURL(Me.shpfFormID)               +  _
             "&SHPF_ACCOUNT_ID="     + encodeURL(Me.accountID)                +  _
             "&SHPF_TPS_DEF="        + encodeURL(Me.shpfTpsDef)               +  _
+            "&SHPF_TPS_HASH_TYPE="  + encodeURL(Me.shpfTpsHashType)          +  _
             "&SHPF_TPS="            + encodeURL(Me.shpfTamperProofSeal)      +  _
             "&MODE="                + encodeURL(Me.mode)                     +  _
             "&TRANSACTION_TYPE="    + encodeURL(Me.transType)                +  _
@@ -973,11 +992,13 @@ Namespace BPVB
             "&DISCOVER_IMAGE="      + encodeURL(Me.discoverImage)            +  _
             "&REDIRECT_URL="        + encodeURL(Me.receiptURL)               +  _
             "&TPS_DEF="             + encodeURL(Me.bp10emuTpsDef)            +  _
+            "&TPS_HASH_TYPE="       + encodeURL(Me.tpsHashType)              +  _
             "&CARD_TYPES="          + encodeURL(Me.cardTypes)
         End Function
 
         Public Function process() As String
             Dim postData As String = "MODE=" + HttpUtility.UrlEncode(Me.mode)
+            postData = postData + "&RESPONSEVERSION=1"
             'If (Me.transType <> "SET" And Me.transType <> "GET") Then
             If (Me.API = "bp10emu") Then
                 calcTPS()
@@ -1115,14 +1136,19 @@ Namespace BPVB
             Dim httpResponse As WebResponse = request.Response()
             responseParams(httpResponse)
         End Sub
-
-
+        
         Public Function responseParams(ByVal httpResponse As WebResponse) As String
-            Dim dataStream As Stream = httpResponse.GetResponseStream()
-            Dim reader As New StreamReader(dataStream)
-            Dim responseFromServer As String = reader.ReadToEnd()
-            Me.response = HttpUtility.UrlDecode(responseFromServer)
-            reader.Close()
+            Dim responseFromServer As String = ""
+            If (Me.api="bp10emu") Then
+                responseFromServer = httpResponse.Headers.Item("Location")
+                Me.response = responseFromServer
+            Else
+                Dim dataStream As Stream = httpResponse.GetResponseStream()
+                Dim reader As New StreamReader(dataStream)
+                responseFromServer = reader.ReadToEnd()
+                Me.response = HttpUtility.UrlDecode(responseFromServer)
+                reader.Close()
+            End If
             Return responseFromServer
         End Function
         

--- a/VB/vbnet/Get_Data/Transaction_Notification.vb
+++ b/VB/vbnet/Get_Data/Transaction_Notification.vb
@@ -23,8 +23,17 @@
         End Sub
 
         Public Shared Sub run()
+            Dim accountID As String = "Merchant's Account ID Here"
+            Dim secretKey As String = "Merchant's Secret Key Here"
+            Dim mode As String = "TEST" 
+
+            Dim tps As BluePay = New BluePay(
+                accountID,
+                secretKey,
+                mode
+            )
+
             Dim listener As HttpListener = New HttpListener()
-            Dim secretKey As String = "MERCHANT'S SECRET KEY HERE"
             Dim prefix As String = "http://localhost:8080/" ' Change this to your listener URL (and optionally port)
             Dim responseString As String = ""
 
@@ -38,7 +47,7 @@
             While (listener.IsListening)
                 Dim context As HttpListenerContext = listener.GetContext()
                 Dim response As HttpListenerResponse = context.Response
-                Dim body = New StreamReader(context.Request.InputStream).ReadToEnd()
+                Dim body As String = New StreamReader(context.Request.InputStream).ReadToEnd()
 
                 ' Return HTTP Status of 200 to BluePay
                 context.Response.StatusCode = 200
@@ -50,13 +59,14 @@
                 response.ContentLength64 = buffer.Length
                 Dim output As System.IO.Stream = response.OutputStream
                 output.Write(buffer, 0, buffer.Length)
-                responseString = Encoding.ASCII.GetString(buffer)
+                responseString = System.Text.Encoding.ASCII.GetString(buffer)
                 context.Response.Close()
 
                 ' Parse data into a NVP collection
                 Dim vals As NameValueCollection = HttpUtility.ParseQueryString(responseString)
                 Dim bpStampDef As String = vals("BP_STAMP_DEF")
-                Dim bpStampVals As String = secretKey
+                Dim tpsHashType As String = vals("TPS_HASH_TYPE")
+                Dim bpStampVals As String
                 Dim strArr() As String
                 Dim i As Integer
                 strArr = bpStampDef.Split(" ")
@@ -65,7 +75,7 @@
                 Next
 
                 ' calculate the expected BP_STAMP
-                Dim bpStamp = BluePay.calcTransNotifyTPS(bpStampVals)
+                Dim bpStamp As String = tps.generateTPS(bpStampVals, tpsHashType)
 
                 ' Output data if the expected bp_stamp matches the actual BP_STAMP
                 If bpStamp = vals("BP_STAMP") Then
@@ -83,3 +93,4 @@
         End Sub
     End Class
  End Namespace
+''

--- a/VB/vbnet/Get_Data/Validate_BP_Stamp.vb
+++ b/VB/vbnet/Get_Data/Validate_BP_Stamp.vb
@@ -1,0 +1,87 @@
+' *
+' * Bluepay VB.NET Sample code.
+' *
+' * This code sample reads the values from a BP10emu redirect
+' * and authenticates the message using the the BP_STAMP
+' * provided in the response. Point the REDIRECT_URL of your 
+' * BP10emu request to the URI prefix specified below.
+' *
+
+ Imports System
+ Imports vbnet.BPVB
+ Imports System.IO
+ Imports System.Collections.Specialized
+ Imports System.Web
+ Imports System.Net
+
+ Namespace GetData
+
+     Public Class ValidateBPStamp
+
+        Public Sub New()
+            MyBase.New()
+        End Sub
+
+        Public Shared Sub run()
+            Dim accountID As String = "Merchant's Account ID Here"
+            Dim secretKey As String = "Merchant's Secret Key Here"
+            Dim mode As String = "TEST" 
+            Dim prefix As String = "Merchant's Target URI Prefix Here" ' Set the listener URI (and port if necessary)
+
+            Dim listener As HttpListener = New HttpListener()
+            listener.Prefixes.Add(prefix)
+
+            Try
+                'Listen for incoming data
+                listener.Start()
+            Catch ex As HttpListenerException
+                Return
+            End Try
+            listener.Prefixes.Add(prefix)
+            While (listener.IsListening)
+                Dim context As HttpListenerContext = listener.GetContext()
+                Dim responsePairs As NameValueCollection = context.Request.QueryString
+                Dim msg As String
+                If responsePairs.Item("BP_STAMP") <> Nothing Then ' Check whether BP_STAMP is provided
+                    Dim bp As BluePay = New BluePay(
+                    accountID,
+                    secretKey,
+                    mode
+                    )
+
+                    Dim bpStampString As String = ""
+                    Dim separator() As String = {" "}
+                    Dim bpStampDef As String = responsePairs.Item("BP_STAMP_DEF")
+                    Dim bpStampFields() As String = bpStampDef.Split(separator, StringSplitOptions.RemoveEmptyEntries) ' Split BP_STAMP_DEF on whitespace
+                    For Each field As String in bpStampFields
+                        bpStampString = bpStampString + responsePairs.Item(field) ' Concatenate values used to calculate expected BP_STAMP
+                    Next
+                    Dim tpsHashType As String = responsePairs.Item("TPS_HASH_TYPE")
+                    Dim expectedStamp As String = bp.generateTPS(bpStampString, tpsHashType) ' Calculate expected BP_STAMP using hash function specified in response
+                    If expectedStamp = responsePairs.Item("BP_STAMP") Then ' Compare expected BP_STAMP with received BP_STAMP
+                        ' Validate BP_STAMP and reads the response results
+                        msg = "VALID BP_STAMP: TRUE" & vbNewLine
+                        For Each key As String in responsePairs
+                            msg = msg + (key + ": " + responsePairs.Item(key) & vbNewLine)
+                        Next
+                    Else
+                        msg = "ERROR: BP_STAMP VALUES DO NOT MATCH" & vbNewLine
+                    End If
+                Else
+                    msg = "ERROR: BP_STAMP NOT FOUND. CHECK MESSAGE & RESPONSEVERSION"
+                End If
+
+                ' Return HTTP Status of 200 to BluePay
+                context.Response.ContentLength64 = msg.Length
+                context.Response.StatusCode = 200
+
+                Using stream As Stream = context.Response.OutputStream
+                    Using writer As StreamWriter = new StreamWriter(stream)
+                        writer.Write(msg)
+                    End Using
+                End Using
+            End While
+            listener.Close()
+        End Sub
+    End Class
+ End Namespace


### PR DESCRIPTION
This updates the following:

- Adds HMAC functionality to all languages.
- Updates URL Generator function with HMAC functionality 
- Adds Validate_BP_Stamp sample script to all languages.
- Changes Trans Notify sample to parse BP_STAMP_DEF instead of using static definition.
- Removes calcTransNotifyTPS functions throughout all libraries (now uses generateTPS function).


